### PR TITLE
New port description

### DIFF
--- a/zenoh-flow-examples/Cargo.toml
+++ b/zenoh-flow-examples/Cargo.toml
@@ -24,6 +24,7 @@ typetag = "0.1"
 log = "0.4"
 bincode = "1"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", default-features = false, features = ["transport_tcp","transport_udp"]  }
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", branch = "master" }
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/zenoh-flow-examples/examples/camera-source.rs
+++ b/zenoh-flow-examples/examples/camera-source.rs
@@ -180,6 +180,6 @@ extern "C" fn register(
         Some(config) => {
             Ok(Box::new(CameraSource::new(config)) as Box<dyn zenoh_flow::SourceTrait + Send>)
         }
-        None => Err(ZFError::MissingConfiguration),
+        None => Ok(Box::new(CameraSource::new(HashMap::new())) as Box<dyn zenoh_flow::SourceTrait + Send>),
     }
 }

--- a/zenoh-flow-examples/examples/camera-source.rs
+++ b/zenoh-flow-examples/examples/camera-source.rs
@@ -104,7 +104,7 @@ impl CameraSource {
     }
 
     async fn run_1(ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.async_lock().await;
         let mut _state = downcast_mut!(CameraState, guard.state).unwrap(); //downcasting to right type

--- a/zenoh-flow-examples/examples/camera-source.rs
+++ b/zenoh-flow-examples/examples/camera-source.rs
@@ -20,7 +20,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
-        ZFContext, ZFError, ZFLinkId, ZFResult,
+        ZFContext, ZFError, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,
@@ -180,6 +180,9 @@ extern "C" fn register(
         Some(config) => {
             Ok(Box::new(CameraSource::new(config)) as Box<dyn zenoh_flow::SourceTrait + Send>)
         }
-        None => Ok(Box::new(CameraSource::new(HashMap::new())) as Box<dyn zenoh_flow::SourceTrait + Send>),
+        None => {
+            Ok(Box::new(CameraSource::new(HashMap::new()))
+                as Box<dyn zenoh_flow::SourceTrait + Send>)
+        }
     }
 }

--- a/zenoh-flow-examples/examples/counter-source.rs
+++ b/zenoh-flow-examples/examples/counter-source.rs
@@ -26,7 +26,7 @@ use zenoh_flow::{
 };
 use zenoh_flow_examples::RandomData;
 
-static SOURCE: &str = "Number";
+static SOURCE: &str = "Counter";
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -46,7 +46,7 @@ impl CountSource {
     }
 
     async fn run_1(_ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
         let d = RandomData {
             d: COUNTER.fetch_add(1, Ordering::AcqRel),
         };

--- a/zenoh-flow-examples/examples/counter-source.rs
+++ b/zenoh-flow-examples/examples/counter-source.rs
@@ -19,7 +19,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
-        ZFContext, ZFLinkId, ZFResult,
+        ZFContext, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_empty_state,

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -21,7 +21,7 @@ use zenoh_flow::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
         OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
     },
-    zf_data, zf_empty_state, Token, ZFContext, ZFLinkId,
+    zf_data, zf_empty_state, Token, ZFContext, ZFPortDescriptor,
 };
 use zenoh_flow_examples::{ZFString, ZFUsize};
 

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -32,7 +32,7 @@ static LINK_ID_INPUT_STR: &str = "Str";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl BuzzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -44,7 +44,7 @@ impl BuzzOperator {
     }
 
     fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results = HashMap::<ZFLinkId, Arc<dyn DataTrait>>::with_capacity(1);
+        let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(1);
 
         let mut buzz = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?.clone();
 
@@ -61,7 +61,7 @@ impl BuzzOperator {
 
     fn output_rule(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
         let mut zf_outputs: HashMap<ZFLinkId, Message> = HashMap::with_capacity(1);
 

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -16,7 +16,7 @@ use async_std::sync::Arc;
 use std::collections::HashMap;
 use zenoh_flow::{
     export_operator, get_input,
-    runtime::message::ZFMessage,
+    runtime::message::Message,
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
         OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
@@ -36,7 +36,7 @@ impl BuzzOperator {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
-                Token::NotReady(_) => return Ok(false),
+                Token::NotReady => return Ok(false),
             }
         }
 
@@ -63,13 +63,11 @@ impl BuzzOperator {
         _ctx: ZFContext,
         outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<ZFLinkId, Arc<ZFMessage>> = HashMap::with_capacity(1);
+        let mut zf_outputs: HashMap<ZFLinkId, Message> = HashMap::with_capacity(1);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),
-            Arc::new(ZFMessage::from_data(
-                outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone(),
-            )),
+            Message::from_data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
         );
 
         Ok(zf_outputs)

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -63,7 +63,7 @@ impl BuzzOperator {
         _ctx: ZFContext,
         outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<ZFLinkId, Message> = HashMap::with_capacity(1);
+        let mut zf_outputs: HashMap<String, Message> = HashMap::with_capacity(1);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -32,7 +32,7 @@ static LINK_ID_INPUT_STR: &str = "Str";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl BuzzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -44,7 +44,7 @@ impl BuzzOperator {
     }
 
     fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results = HashMap::<ZFLinkId, Arc<dyn DataTrait>>::with_capacity(1);
+        let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(1);
 
         let mut buzz = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?.clone();
 
@@ -61,9 +61,9 @@ impl BuzzOperator {
 
     fn output_rule(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<ZFLinkId, Arc<ZFMessage>> = HashMap::with_capacity(1);
+        let mut zf_outputs: HashMap<String, Arc<ZFMessage>> = HashMap::with_capacity(1);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),

--- a/zenoh-flow-examples/examples/example-fizz.rs
+++ b/zenoh-flow-examples/examples/example-fizz.rs
@@ -23,7 +23,7 @@ use zenoh_flow::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
         OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
     },
-    zf_data, zf_empty_state, Token, ZFContext, ZFLinkId,
+    zf_data, zf_empty_state, Token, ZFContext, ZFPortDescriptor,
 };
 
 struct FizzOperator;

--- a/zenoh-flow-examples/examples/example-fizz.rs
+++ b/zenoh-flow-examples/examples/example-fizz.rs
@@ -33,7 +33,7 @@ static LINK_ID_OUTPUT_INT: &str = "Int";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl FizzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -45,7 +45,7 @@ impl FizzOperator {
     }
 
     fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results = HashMap::<ZFLinkId, Arc<dyn DataTrait>>::with_capacity(2);
+        let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(2);
 
         let mut fizz = ZFString::from("");
 
@@ -63,9 +63,9 @@ impl FizzOperator {
 
     fn output_rule(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<ZFLinkId, Arc<ZFMessage>> = HashMap::with_capacity(2);
+        let mut zf_outputs: HashMap<String, Arc<ZFMessage>> = HashMap::with_capacity(2);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_INT),

--- a/zenoh-flow-examples/examples/example-fizz.rs
+++ b/zenoh-flow-examples/examples/example-fizz.rs
@@ -33,7 +33,7 @@ static LINK_ID_OUTPUT_INT: &str = "Int";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl FizzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -45,7 +45,7 @@ impl FizzOperator {
     }
 
     fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results = HashMap::<ZFLinkId, Arc<dyn DataTrait>>::with_capacity(2);
+        let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(2);
 
         let mut fizz = ZFString::from("");
 
@@ -63,7 +63,7 @@ impl FizzOperator {
 
     fn output_rule(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
         let mut zf_outputs: HashMap<ZFLinkId, Message> = HashMap::with_capacity(2);
 

--- a/zenoh-flow-examples/examples/example-fizz.rs
+++ b/zenoh-flow-examples/examples/example-fizz.rs
@@ -65,7 +65,7 @@ impl FizzOperator {
         _ctx: ZFContext,
         outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<ZFLinkId, Message> = HashMap::with_capacity(2);
+        let mut zf_outputs: HashMap<String, Message> = HashMap::with_capacity(2);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_INT),

--- a/zenoh-flow-examples/examples/example-fizz.rs
+++ b/zenoh-flow-examples/examples/example-fizz.rs
@@ -17,13 +17,13 @@ use std::collections::HashMap;
 use zenoh_flow_examples::{ZFString, ZFUsize};
 
 use zenoh_flow::{
-    downcast, export_operator, get_input,
-    runtime::message::ZFMessage,
+    export_operator, get_input,
+    runtime::message::Message,
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
         OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
     },
-    zf_data, zf_empty_state, Token, ZFContext, ZFError, ZFLinkId,
+    zf_data, zf_empty_state, Token, ZFContext, ZFLinkId,
 };
 
 struct FizzOperator;
@@ -37,7 +37,7 @@ impl FizzOperator {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
-                Token::NotReady(_) => return Ok(false),
+                Token::NotReady => return Ok(false),
             }
         }
 
@@ -65,19 +65,15 @@ impl FizzOperator {
         _ctx: ZFContext,
         outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<ZFLinkId, Arc<ZFMessage>> = HashMap::with_capacity(2);
+        let mut zf_outputs: HashMap<ZFLinkId, Message> = HashMap::with_capacity(2);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_INT),
-            Arc::new(ZFMessage::from_data(
-                outputs.get(LINK_ID_OUTPUT_INT).unwrap().clone(),
-            )),
+            Message::from_data(outputs.get(LINK_ID_OUTPUT_INT).unwrap().clone()),
         );
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),
-            Arc::new(ZFMessage::from_data(
-                outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone(),
-            )),
+            Message::from_data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
         );
 
         Ok(zf_outputs)

--- a/zenoh-flow-examples/examples/example-select.rs
+++ b/zenoh-flow-examples/examples/example-select.rs
@@ -14,10 +14,10 @@ async fn send<T: Clone>(sender: ZFLinkSender<T>, interveal: Duration, data: T) {
 
 #[async_std::main]
 async fn main() {
-    let (s1, mut r1) = link::<u8>(Some(10), String::from("0"));
-    let (s2, mut r2) = link::<u8>(Some(10), String::from("1"));
-    let (s3, mut r3) = link::<u8>(Some(10), String::from("2"));
-    let (s4, mut r4) = link::<u8>(Some(10), String::from("3"));
+    let (s1, mut r1) = link::<u8>(Some(10), String::from("0"), String::from("10"));
+    let (s2, mut r2) = link::<u8>(Some(10), String::from("1"), String::from("11"));
+    let (s3, mut r3) = link::<u8>(Some(10), String::from("2"), String::from("12"));
+    let (s4, mut r4) = link::<u8>(Some(10), String::from("3"), String::from("13"));
 
     let _h1 = async_std::task::spawn(async move {
         send(s1, Duration::from_secs(1), 0u8).await;

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -24,8 +24,8 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFLinkId,
-        ZFResult,
+        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput,
+        ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::io;
 use zenoh_flow::{
     downcast, downcast_mut, get_input,
-    runtime::message::ZFMessage,
+    runtime::message::Message,
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
@@ -85,7 +85,7 @@ impl FaceDetection {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))
@@ -183,7 +183,7 @@ impl FaceDetection {
         let mut results = HashMap::new();
         for (k, v) in outputs {
             // should be ZFMessage::from_data
-            results.insert(k, Arc::new(ZFMessage::from_data(v)));
+            results.insert(k, Message::from_data(v));
         }
         Ok(results)
     }

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -178,7 +178,7 @@ impl FaceDetection {
 
     pub fn or_1(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -81,7 +81,7 @@ impl FaceDetection {
         Self { state }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -93,7 +93,7 @@ impl FaceDetection {
     }
 
     pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.lock(); //getting state
         let _state = downcast!(FDState, guard.state).unwrap(); //downcasting to right type
@@ -175,18 +175,6 @@ impl FaceDetection {
 
         Ok(results)
     }
-
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut results = HashMap::new();
-        for (k, v) in outputs {
-            // should be ZFMessage::from_data
-            results.insert(k, Arc::new(ZFMessage::from_data(v)));
-        }
-        Ok(results)
-    }
 }
 
 impl OperatorTrait for FaceDetection {
@@ -195,7 +183,7 @@ impl OperatorTrait for FaceDetection {
     }
 
     fn get_output_rule(&self, ctx: ZFContext) -> Box<FnOutputRule> {
-        Box::new(Self::or_1)
+        Box::new(zenoh_flow::default_output_rule)
     }
 
     fn get_run(&self, ctx: ZFContext) -> Box<FnRun> {

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -81,7 +81,7 @@ impl FaceDetection {
         Self { state }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -93,7 +93,7 @@ impl FaceDetection {
     }
 
     pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.lock(); //getting state
         let _state = downcast!(FDState, guard.state).unwrap(); //downcasting to right type
@@ -195,7 +195,7 @@ impl OperatorTrait for FaceDetection {
     }
 
     fn get_output_rule(&self, ctx: ZFContext) -> Box<FnOutputRule> {
-        Box::new(Self::or_1)
+        Box::new(zenoh_flow::default_output_rule)
     }
 
     fn get_run(&self, ctx: ZFContext) -> Box<FnRun> {

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -175,21 +175,6 @@ impl FaceDetection {
 
         Ok(results)
     }
-<<<<<<< HEAD
-
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut results = HashMap::new();
-        for (k, v) in outputs {
-            // should be ZFMessage::from_data
-            results.insert(k, Message::from_data(v));
-        }
-        Ok(results)
-    }
-=======
->>>>>>> 274856298d90c91cd16cd8844da79d128cb42490
 }
 
 impl OperatorTrait for FaceDetection {

--- a/zenoh-flow-examples/examples/frame-concat.rs
+++ b/zenoh-flow-examples/examples/frame-concat.rs
@@ -74,7 +74,7 @@ impl FrameConcat {
     }
 
     pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.lock(); //getting state
         let _state = downcast!(ConcatState, guard.state).unwrap(); //downcasting to right type
@@ -116,17 +116,6 @@ impl FrameConcat {
         Ok(results)
     }
 
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut results = HashMap::new();
-        for (k, v) in outputs {
-            // should be ZFMessage::from_data
-            results.insert(k, Arc::new(ZFMessage::from_data(v)));
-        }
-        Ok(results)
-    }
 }
 
 impl OperatorTrait for FrameConcat {

--- a/zenoh-flow-examples/examples/frame-concat.rs
+++ b/zenoh-flow-examples/examples/frame-concat.rs
@@ -24,8 +24,8 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFLinkId,
-        ZFResult,
+        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput,
+        ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,

--- a/zenoh-flow-examples/examples/frame-concat.rs
+++ b/zenoh-flow-examples/examples/frame-concat.rs
@@ -74,7 +74,7 @@ impl FrameConcat {
     }
 
     pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.lock(); //getting state
         let _state = downcast!(ConcatState, guard.state).unwrap(); //downcasting to right type

--- a/zenoh-flow-examples/examples/frame-concat.rs
+++ b/zenoh-flow-examples/examples/frame-concat.rs
@@ -115,7 +115,6 @@ impl FrameConcat {
 
         Ok(results)
     }
-
 }
 
 impl OperatorTrait for FrameConcat {

--- a/zenoh-flow-examples/examples/frame-concat.rs
+++ b/zenoh-flow-examples/examples/frame-concat.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::io;
 use zenoh_flow::{
     downcast, downcast_mut, get_input,
-    runtime::message::ZFMessage,
+    runtime::message::Message,
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
@@ -116,17 +116,6 @@ impl FrameConcat {
         Ok(results)
     }
 
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut results = HashMap::new();
-        for (k, v) in outputs {
-            // should be ZFMessage::from_data
-            results.insert(k, Arc::new(ZFMessage::from_data(v)));
-        }
-        Ok(results)
-    }
 }
 
 impl OperatorTrait for FrameConcat {

--- a/zenoh-flow-examples/examples/generic-sink.rs
+++ b/zenoh-flow-examples/examples/generic-sink.rs
@@ -27,7 +27,7 @@ use zenoh_flow::{
 struct ExampleGenericSink {}
 
 impl ExampleGenericSink {
-    pub fn ir_1(_ctx: ZFContext, _inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, _inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         Ok(true)
     }
 

--- a/zenoh-flow-examples/examples/generic-sink.rs
+++ b/zenoh-flow-examples/examples/generic-sink.rs
@@ -17,7 +17,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         FnInputRule, FnSinkRun, FutSinkResult, InputRuleResult, SinkTrait, StateTrait, Token,
-        ZFContext, ZFInput, ZFLinkId,
+        ZFContext, ZFInput, ZFPortDescriptor,
     },
     zenoh_flow_derive::ZFState,
     zf_empty_state, ZFResult,

--- a/zenoh-flow-examples/examples/manual-source.rs
+++ b/zenoh-flow-examples/examples/manual-source.rs
@@ -19,7 +19,7 @@ use zenoh_flow::{
     types::{
         DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
     },
-    zf_data, zf_empty_state, ZFContext, ZFError, ZFLinkId, ZFResult,
+    zf_data, zf_empty_state, ZFContext, ZFError, ZFPortDescriptor, ZFResult,
 };
 use zenoh_flow_examples::ZFUsize;
 

--- a/zenoh-flow-examples/examples/manual-source.rs
+++ b/zenoh-flow-examples/examples/manual-source.rs
@@ -29,7 +29,7 @@ static LINK_ID_INPUT_INT: &str = "Int";
 
 impl ManualSource {
     async fn run(_ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::with_capacity(1);
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::with_capacity(1);
 
         println!("> Please input a number: ");
         let mut number = String::new();

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use zenoh_flow::{
     downcast, downcast_mut, get_input,
-    runtime::message::ZFMessage,
+    runtime::message::Message,
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
@@ -122,7 +122,7 @@ impl ObjDetection {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))
@@ -331,8 +331,7 @@ impl ObjDetection {
     ) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {
-            // should be ZFMessage::from_data
-            results.insert(k, Arc::new(ZFMessage::from_data(v)));
+            results.insert(k, Message::from_data(v));
         }
         Ok(results)
     }

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -325,10 +325,7 @@ impl ObjDetection {
         Ok(results)
     }
 
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
+    pub fn or_1(_ctx: ZFContext, outputs: HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {
             results.insert(k, Message::from_data(v));

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -118,7 +118,7 @@ impl ObjDetection {
         Ok(Self { state })
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -133,7 +133,7 @@ impl ObjDetection {
         let scale = 1.0 / 255.0;
         let mean = core::Scalar::new(0f64, 0f64, 0f64, 0f64);
 
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut detections: opencv::types::VectorOfMat = core::Vector::new();
 
@@ -327,7 +327,7 @@ impl ObjDetection {
 
     pub fn or_1(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -29,8 +29,8 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFLinkId,
-        ZFResult,
+        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput,
+        ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -325,10 +325,7 @@ impl ObjDetection {
         Ok(results)
     }
 
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
+    pub fn or_1(_ctx: ZFContext, outputs: HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {
             // should be ZFMessage::from_data

--- a/zenoh-flow-examples/examples/random-source.rs
+++ b/zenoh-flow-examples/examples/random-source.rs
@@ -25,14 +25,14 @@ use zenoh_flow::{
 };
 use zenoh_flow_examples::RandomData;
 
-static SOURCE: &str = "Number";
+static SOURCE: &str = "Random";
 
 #[derive(Serialize, Deserialize, Debug, ZFState)]
 struct ExampleRandomSource {}
 
 impl ExampleRandomSource {
     async fn run_1(_ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
         let d = RandomData {
             d: rand::random::<u64>(),
         };

--- a/zenoh-flow-examples/examples/random-source.rs
+++ b/zenoh-flow-examples/examples/random-source.rs
@@ -18,7 +18,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
-        ZFContext, ZFLinkId, ZFResult,
+        ZFContext, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_empty_state,

--- a/zenoh-flow-examples/examples/sum-and-send.rs
+++ b/zenoh-flow-examples/examples/sum-and-send.rs
@@ -74,10 +74,7 @@ impl SumAndSend {
         Ok(results)
     }
 
-    pub fn or_1(
-        _ctx: ZFContext,
-        outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
+    pub fn or_1(_ctx: ZFContext, outputs: HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {
             // should be ZFMessage::from_data

--- a/zenoh-flow-examples/examples/sum-and-send.rs
+++ b/zenoh-flow-examples/examples/sum-and-send.rs
@@ -14,7 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use zenoh_flow::runtime::message::ZFMessage;
+use zenoh_flow::runtime::message::Message;
 use zenoh_flow::types::{
     DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait, OutputRuleResult,
     RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFLinkId, ZFResult,
@@ -51,7 +51,7 @@ impl SumAndSend {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))
@@ -81,7 +81,7 @@ impl SumAndSend {
         let mut results = HashMap::new();
         for (k, v) in outputs {
             // should be ZFMessage::from_data
-            results.insert(k, Arc::new(ZFMessage::from_data(v)));
+            results.insert(k, Message::from_data(v));
         }
         Ok(results)
     }

--- a/zenoh-flow-examples/examples/sum-and-send.rs
+++ b/zenoh-flow-examples/examples/sum-and-send.rs
@@ -36,7 +36,7 @@ struct SumAndSendState {
 }
 
 static INPUT: &str = "Number";
-static OUTPUT: &str = "Number";
+static OUTPUT: &str = "Sum";
 
 impl SumAndSend {
     pub fn new() -> Self {
@@ -47,7 +47,7 @@ impl SumAndSend {
         }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -59,7 +59,7 @@ impl SumAndSend {
     }
 
     pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.lock(); //getting the context
         let mut _state = downcast_mut!(SumAndSendState, guard.state).unwrap(); //getting and downcasting  state to right type
@@ -76,7 +76,7 @@ impl SumAndSend {
 
     pub fn or_1(
         _ctx: ZFContext,
-        outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+        outputs: HashMap<String, Arc<dyn DataTrait>>,
     ) -> OutputRuleResult {
         let mut results = HashMap::new();
         for (k, v) in outputs {

--- a/zenoh-flow-examples/examples/sum-and-send.rs
+++ b/zenoh-flow-examples/examples/sum-and-send.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use zenoh_flow::runtime::message::Message;
 use zenoh_flow::types::{
     DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait, OutputRuleResult,
-    RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFLinkId, ZFResult,
+    RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFPortDescriptor, ZFResult,
 };
 use zenoh_flow::zenoh_flow_derive::ZFState;
 use zenoh_flow::{downcast_mut, get_input, zf_data};

--- a/zenoh-flow-examples/examples/video-file-source.rs
+++ b/zenoh-flow-examples/examples/video-file-source.rs
@@ -92,7 +92,7 @@ impl VideoSource {
     }
 
     async fn run_1(ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.async_lock().await;
         let mut _state = downcast_mut!(VideoState, guard.state).unwrap(); //downcasting to right type

--- a/zenoh-flow-examples/examples/video-file-source.rs
+++ b/zenoh-flow-examples/examples/video-file-source.rs
@@ -20,7 +20,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
-        ZFContext, ZFError, ZFLinkId, ZFResult,
+        ZFContext, ZFError, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -1,273 +1,287 @@
-// //
-// // Copyright (c) 2017, 2021 ADLINK Technology Inc.
-// //
-// // This program and the accompanying materials are made available under the
-// // terms of the Eclipse Public License 2.0 which is available at
-// // http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// // which is available at https://www.apache.org/licenses/LICENSE-2.0.
-// //
-// // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-// //
-// // Contributors:
-// //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
-// //
+//
+// Copyright (c) 2017, 2021 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
 
-// use async_std::sync::{Arc, Mutex};
-// use std::collections::HashMap;
-// use zenoh_flow::model::link::{ZFFromEndpoint, ZFToEndpoint};
-// use zenoh_flow::{
-//     downcast, downcast_mut, get_input,
-//     serde::{Deserialize, Serialize},
-//     types::{
-//         DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunResult, FutSinkResult,
-//         InputRuleResult, RunResult, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
-//         ZFInput, ZFLinkId, ZFResult,
-//     },
-//     zenoh_flow_derive::ZFState,
-//     zf_data, zf_spin_lock,
-// };
-// use zenoh_flow_examples::ZFBytes;
+use async_std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use zenoh_flow::model::link::{ZFFromEndpoint, ZFToEndpoint};
+use zenoh_flow::{
+    downcast, downcast_mut, get_input,
+    serde::{Deserialize, Serialize},
+    types::{
+        DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunResult, FutSinkResult,
+        InputRuleResult, RunResult, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
+        ZFInput, ZFLinkId, ZFResult,
+    },
+    zenoh_flow_derive::ZFState,
+    zf_data, zf_spin_lock,
+};
+use zenoh_flow_examples::ZFBytes;
+use std::fs::{File, *};
+use opencv::{core, highgui, prelude::*, videoio};
+use std::io::Write;
 
-// use opencv::{core, highgui, prelude::*, videoio};
+static SOURCE: &str = "Frame";
+static INPUT: &str = "Frame";
 
-// static SOURCE: &str = "Frame";
-// static INPUT: &str = "Frame";
+#[derive(Debug)]
+struct CameraSource {
+    pub state: CameraState,
+}
 
-// #[derive(Debug)]
-// struct CameraSource {
-//     pub state: CameraState,
-// }
+#[derive(Clone)]
+struct InnerCameraAccess {
+    pub camera: Arc<Mutex<videoio::VideoCapture>>,
+    pub encode_options: Arc<Mutex<opencv::types::VectorOfi32>>,
+}
 
-// #[derive(Clone)]
-// struct InnerCameraAccess {
-//     pub camera: Arc<Mutex<videoio::VideoCapture>>,
-//     pub encode_options: Arc<Mutex<opencv::types::VectorOfi32>>,
-// }
+#[derive(Serialize, Deserialize, ZFState, Clone)]
+struct CameraState {
+    #[serde(skip_serializing, skip_deserializing)]
+    pub inner: Option<InnerCameraAccess>,
 
-// #[derive(Serialize, Deserialize, ZFState, Clone)]
-// struct CameraState {
-//     #[serde(skip_serializing, skip_deserializing)]
-//     pub inner: Option<InnerCameraAccess>,
+    pub resolution: (i32, i32),
+    pub delay: u64,
+}
 
-//     pub resolution: (i32, i32),
-//     pub delay: u64,
-// }
+// because of opencv
+impl std::fmt::Debug for CameraState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "CameraState: resolution:{:?} delay:{:?}",
+            self.resolution, self.delay
+        )
+    }
+}
 
-// // because of opencv
-// impl std::fmt::Debug for CameraState {
-//     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-//         write!(
-//             f,
-//             "CameraState: resolution:{:?} delay:{:?}",
-//             self.resolution, self.delay
-//         )
-//     }
-// }
+impl CameraSource {
+    fn new() -> Self {
+        let mut camera = videoio::VideoCapture::new(0, videoio::CAP_ANY).unwrap(); // 0 is the default camera
+        let opened = videoio::VideoCapture::is_opened(&camera).unwrap();
+        if !opened {
+            panic!("Unable to open default camera!");
+        }
+        let mut encode_options = opencv::types::VectorOfi32::new();
+        encode_options.push(opencv::imgcodecs::IMWRITE_JPEG_QUALITY);
+        encode_options.push(90);
+        let inner = InnerCameraAccess {
+            camera: Arc::new(Mutex::new(camera)),
+            encode_options: Arc::new(Mutex::new(encode_options)),
+        };
 
-// impl CameraSource {
-//     fn new() -> Self {
-//         let mut camera = videoio::VideoCapture::new(0, videoio::CAP_ANY).unwrap(); // 0 is the default camera
-//         let opened = videoio::VideoCapture::is_opened(&camera).unwrap();
-//         if !opened {
-//             panic!("Unable to open default camera!");
-//         }
-//         let mut encode_options = opencv::types::VectorOfi32::new();
-//         encode_options.push(opencv::imgcodecs::IMWRITE_JPEG_QUALITY);
-//         encode_options.push(90);
-//         let inner = InnerCameraAccess {
-//             camera: Arc::new(Mutex::new(camera)),
-//             encode_options: Arc::new(Mutex::new(encode_options)),
-//         };
+        let state = CameraState {
+            inner: Some(inner),
+            resolution: (800, 600),
+            delay: 40,
+        };
 
-//         let state = CameraState {
-//             inner: Some(inner),
-//             resolution: (800, 600),
-//             delay: 40,
-//         };
+        Self { state }
+    }
 
-//         Self { state }
-//     }
+    async fn run_1(ctx: ZFContext) -> RunResult {
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
-//     async fn run_1(ctx: ZFContext) -> RunResult {
-//         let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut guard = ctx.async_lock().await;
+        let mut _state = downcast_mut!(CameraState, guard.state).unwrap(); //downcasting to right type
 
-//         let mut guard = ctx.async_lock().await;
-//         let mut _state = downcast_mut!(CameraState, guard.state).unwrap(); //downcasting to right type
+        let inner = _state.inner.as_ref().unwrap();
 
-//         let inner = _state.inner.as_ref().unwrap();
+        let mut cam = zf_spin_lock!(inner.camera);
+        let encode_options = zf_spin_lock!(inner.encode_options);
 
-//         let mut cam = zf_spin_lock!(inner.camera);
-//         let encode_options = zf_spin_lock!(inner.encode_options);
+        let mut frame = core::Mat::default();
+        cam.read(&mut frame).unwrap();
 
-//         let mut frame = core::Mat::default();
-//         cam.read(&mut frame).unwrap();
+        let mut reduced = Mat::default();
+        opencv::imgproc::resize(
+            &frame,
+            &mut reduced,
+            opencv::core::Size::new(_state.resolution.0, _state.resolution.0),
+            0.0,
+            0.0,
+            opencv::imgproc::INTER_LINEAR,
+        )
+        .unwrap();
 
-//         let mut reduced = Mat::default();
-//         opencv::imgproc::resize(
-//             &frame,
-//             &mut reduced,
-//             opencv::core::Size::new(_state.resolution.0, _state.resolution.0),
-//             0.0,
-//             0.0,
-//             opencv::imgproc::INTER_LINEAR,
-//         )
-//         .unwrap();
+        let mut buf = opencv::types::VectorOfu8::new();
+        opencv::imgcodecs::imencode(".jpeg", &reduced, &mut buf, &encode_options).unwrap();
 
-//         let mut buf = opencv::types::VectorOfu8::new();
-//         opencv::imgcodecs::imencode(".jpeg", &reduced, &mut buf, &encode_options).unwrap();
+        let data = ZFBytes {
+            bytes: buf.to_vec(),
+        };
 
-//         let data = ZFBytes {
-//             bytes: buf.to_vec(),
-//         };
+        results.insert(String::from(SOURCE), zf_data!(data));
 
-//         results.insert(String::from(SOURCE), zf_data!(data));
+        async_std::task::sleep(std::time::Duration::from_millis(_state.delay));
 
-//         async_std::task::sleep(std::time::Duration::from_millis(_state.delay));
+        drop(cam);
+        drop(encode_options);
 
-//         drop(cam);
-//         drop(encode_options);
+        Ok(results)
+    }
+}
 
-//         Ok(results)
-//     }
-// }
+impl SourceTrait for CameraSource {
+    fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
+        Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) })
+    }
 
-// impl SourceTrait for CameraSource {
-//     fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
-//         Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) })
-//     }
+    fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
+        Box::new(zenoh_flow::default_output_rule)
+    }
 
-//     fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
-//         Box::new(zenoh_flow::default_output_rule)
-//     }
+    fn get_state(&self) -> Box<dyn StateTrait> {
+        Box::new(self.state.clone())
+    }
+}
 
-//     fn get_state(&self) -> Box<dyn StateTrait> {
-//         Box::new(self.state.clone())
-//     }
-// }
+#[derive(Debug)]
+struct VideoSink {
+    pub state: VideoState,
+}
 
-// #[derive(Debug)]
-// struct VideoSink {
-//     pub state: VideoState,
-// }
+#[derive(Serialize, Deserialize, ZFState, Clone, Debug)]
+struct VideoState {
+    pub window_name: String,
+}
 
-// #[derive(Serialize, Deserialize, ZFState, Clone, Debug)]
-// struct VideoState {
-//     pub window_name: String,
-// }
+impl VideoSink {
+    pub fn new() -> Self {
+        let window_name = &format!("Video-Sink");
+        highgui::named_window(window_name, 1).unwrap();
+        let state = VideoState {
+            window_name: window_name.to_string(),
+        };
+        Self { state }
+    }
 
-// impl VideoSink {
-//     pub fn new() -> Self {
-//         let window_name = &format!("Video-Sink");
-//         highgui::named_window(window_name, 1).unwrap();
-//         let state = VideoState {
-//             window_name: window_name.to_string(),
-//         };
-//         Self { state }
-//     }
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+        if let Some(token) = inputs.get(INPUT) {
+            match token {
+                Token::Ready(_) => Ok(true),
+                Token::NotReady(_) => Ok(false),
+            }
+        } else {
+            Err(ZFError::MissingInput(String::from(INPUT)))
+        }
+    }
 
-//     pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
-//         if let Some(token) = inputs.get(INPUT) {
-//             match token {
-//                 Token::Ready(_) => Ok(true),
-//                 Token::NotReady(_) => Ok(false),
-//             }
-//         } else {
-//             Err(ZFError::MissingInput(String::from(INPUT)))
-//         }
-//     }
+    pub async fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> ZFResult<()> {
+        let guard = ctx.async_lock().await; //getting state,
+        let _state = downcast!(VideoState, guard.state).unwrap(); //downcasting to right type
 
-//     pub async fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> ZFResult<()> {
-//         let guard = ctx.async_lock().await; //getting state,
-//         let _state = downcast!(VideoState, guard.state).unwrap(); //downcasting to right type
+        let data = get_input!(ZFBytes, String::from(INPUT), inputs).unwrap();
 
-//         let data = get_input!(ZFBytes, String::from(INPUT), inputs).unwrap();
+        let decoded = opencv::imgcodecs::imdecode(
+            &opencv::types::VectorOfu8::from_iter(data.bytes.clone()),
+            opencv::imgcodecs::IMREAD_COLOR,
+        )
+        .unwrap();
 
-//         let decoded = opencv::imgcodecs::imdecode(
-//             &opencv::types::VectorOfu8::from_iter(data.bytes.clone()),
-//             opencv::imgcodecs::IMREAD_COLOR,
-//         )
-//         .unwrap();
+        if decoded.size().unwrap().width > 0 {
+            highgui::imshow(&_state.window_name, &decoded).unwrap();
+        }
 
-//         if decoded.size().unwrap().width > 0 {
-//             highgui::imshow(&_state.window_name, &decoded).unwrap();
-//         }
+        highgui::wait_key(10).unwrap();
+        Ok(())
+    }
+}
 
-//         highgui::wait_key(10).unwrap();
-//         Ok(())
-//     }
-// }
+impl SinkTrait for VideoSink {
+    fn get_input_rule(&self, ctx: ZFContext) -> Box<FnInputRule> {
+        Box::new(Self::ir_1)
+    }
 
-// impl SinkTrait for VideoSink {
-//     fn get_input_rule(&self, ctx: ZFContext) -> Box<FnInputRule> {
-//         Box::new(Self::ir_1)
-//     }
+    fn get_run(&self, ctx: ZFContext) -> FnSinkRun {
+        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
+            Box::pin(Self::run_1(ctx, inputs))
+        })
+    }
 
-//     fn get_run(&self, ctx: ZFContext) -> FnSinkRun {
-//         Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
-//             Box::pin(Self::run_1(ctx, inputs))
-//         })
-//     }
+    fn get_state(&self) -> Box<dyn StateTrait> {
+        Box::new(self.state.clone())
+    }
+}
 
-//     fn get_state(&self) -> Box<dyn StateTrait> {
-//         Box::new(self.state.clone())
-//     }
-// }
+#[async_std::main]
+async fn main() {
 
-// #[async_std::main]
-// async fn main() {
-//     let mut zf_graph = zenoh_flow::runtime::graph::DataFlowGraph::new();
+    env_logger::init();
 
-//     let source = Box::new(CameraSource::new());
-//     let sink = Box::new(VideoSink::new());
+    let mut zf_graph = zenoh_flow::runtime::graph::DataFlowGraph::new();
 
-//     zf_graph
-//         .add_static_source(
-//             "camera-source".to_string(),
-//             // "camera".to_string(),
-//             String::from(SOURCE),
-//             source,
-//             None,
-//         )
-//         .unwrap();
+    let source = Box::new(CameraSource::new());
+    let sink = Box::new(VideoSink::new());
 
-//     zf_graph
-//         .add_static_sink(
-//             "video-sink".to_string(),
-//             // "window".to_string(),
-//             String::from(INPUT),
-//             sink,
-//             None,
-//         )
-//         .unwrap();
+    zf_graph
+        .add_static_source(
+            "camera-source".to_string(),
+            ZFLinkId {
+                name: String::from(SOURCE),
+                type_name: String::from("image"),
+            },
+            source,
+            None,
+        )
+        .unwrap();
 
-//     zf_graph
-//         .add_link(
-//             ZFFromEndpoint {
-//                 id: "camera-source".to_string(),
-//                 output: String::from(SOURCE),
-//             },
-//             ZFToEndpoint {
-//                 id: "video-sink".to_string(),
-//                 input: String::from(INPUT),
-//             },
-//             None,
-//             None,
-//             None,
-//         )
-//         .unwrap();
+    zf_graph
+        .add_static_sink(
+            "video-sink".to_string(),
+            ZFLinkId {
+                name: String::from(INPUT),
+                type_name: String::from("image"),
+            },
+            sink,
+            None,
+        )
+        .unwrap();
 
-//     zf_graph.make_connections("local").await;
+    zf_graph
+        .add_link(
+            ZFFromEndpoint {
+                id: "camera-source".to_string(),
+                output: String::from(SOURCE),
+            },
+            ZFToEndpoint {
+                id: "video-sink".to_string(),
+                input: String::from(INPUT),
+            },
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
-//     let runners = zf_graph.get_runners();
-//     for runner in runners {
-//         async_std::task::spawn(async move {
-//             let mut runner = runner.lock().await;
-//             runner.run().await.unwrap();
-//         });
-//     }
 
-//     let () = std::future::pending().await;
-// }
-pub fn main(){
-    println!("hello world!");
+    let dot_notation = zf_graph.to_dot_notation();
+
+    let mut file = File::create("video-pipeline.dot").unwrap();
+    write!(file, "{}", dot_notation).unwrap();
+    file.sync_all().unwrap();
+
+    zf_graph.make_connections("self").await.unwrap();
+
+
+
+    let runners = zf_graph.get_runners();
+    for runner in runners {
+        async_std::task::spawn(async move {
+            let mut runner = runner.lock().await;
+            runner.run().await.unwrap();
+        });
+    }
+
+    let () = std::future::pending().await;
 }

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -17,7 +17,7 @@ use opencv::{core, highgui, prelude::*, videoio};
 use std::collections::HashMap;
 use std::fs::{File, *};
 use std::io::Write;
-use zenoh_flow::model::link::{ZFFromEndpoint, ZFToEndpoint};
+use zenoh_flow::model::link::{ZFPortFrom, ZFPortTo};
 use zenoh_flow::{
     downcast, downcast_mut, get_input,
     serde::{Deserialize, Serialize},
@@ -251,11 +251,11 @@ async fn main() {
 
     zf_graph
         .add_link(
-            ZFFromEndpoint {
+            ZFPortFrom {
                 id: "camera-source".to_string(),
                 output_id: String::from(SOURCE),
             },
-            ZFToEndpoint {
+            ZFPortTo {
                 id: "video-sink".to_string(),
                 input_id: String::from(INPUT),
             },

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -258,7 +258,7 @@ async fn main() {
         )
         .unwrap();
 
-    zf_graph.make_connections("local").await;
+    zf_graph.make_connections("self").await;
 
     let runners = zf_graph.get_runners();
     for runner in runners {

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -13,7 +13,10 @@
 //
 
 use async_std::sync::{Arc, Mutex};
+use opencv::{core, highgui, prelude::*, videoio};
 use std::collections::HashMap;
+use std::fs::{File, *};
+use std::io::Write;
 use zenoh_flow::model::link::{ZFFromEndpoint, ZFToEndpoint};
 use zenoh_flow::{
     downcast, downcast_mut, get_input,
@@ -21,15 +24,12 @@ use zenoh_flow::{
     types::{
         DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunResult, FutSinkResult,
         InputRuleResult, RunResult, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
-        ZFInput, ZFLinkId, ZFResult,
+        ZFInput, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,
 };
 use zenoh_flow_examples::ZFBytes;
-use std::fs::{File, *};
-use opencv::{core, highgui, prelude::*, videoio};
-use std::io::Write;
 
 static SOURCE: &str = "Frame";
 static INPUT: &str = "Frame";
@@ -216,7 +216,6 @@ impl SinkTrait for VideoSink {
 
 #[async_std::main]
 async fn main() {
-
     env_logger::init();
 
     let mut zf_graph = zenoh_flow::runtime::graph::DataFlowGraph::new();
@@ -229,9 +228,9 @@ async fn main() {
         .add_static_source(
             hlc,
             "camera-source".to_string(),
-            ZFLinkId {
-                name: String::from(SOURCE),
-                type_name: String::from("image"),
+            ZFPortDescriptor {
+                port_id: String::from(SOURCE),
+                port_type: String::from("image"),
             },
             source,
             None,
@@ -241,9 +240,9 @@ async fn main() {
     zf_graph
         .add_static_sink(
             "video-sink".to_string(),
-            ZFLinkId {
-                name: String::from(INPUT),
-                type_name: String::from("image"),
+            ZFPortDescriptor {
+                port_id: String::from(INPUT),
+                port_type: String::from("image"),
             },
             sink,
             None,
@@ -254,18 +253,17 @@ async fn main() {
         .add_link(
             ZFFromEndpoint {
                 id: "camera-source".to_string(),
-                output: String::from(SOURCE),
+                output_id: String::from(SOURCE),
             },
             ZFToEndpoint {
                 id: "video-sink".to_string(),
-                input: String::from(INPUT),
+                input_id: String::from(INPUT),
             },
             None,
             None,
             None,
         )
         .unwrap();
-
 
     let dot_notation = zf_graph.to_dot_notation();
 
@@ -274,8 +272,6 @@ async fn main() {
     file.sync_all().unwrap();
 
     zf_graph.make_connections("self").await.unwrap();
-
-
 
     let runners = zf_graph.get_runners();
     for runner in runners {

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -170,7 +170,7 @@ impl VideoSink {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))
@@ -223,9 +223,11 @@ async fn main() {
 
     let source = Box::new(CameraSource::new());
     let sink = Box::new(VideoSink::new());
+    let hlc = Arc::new(uhlc::HLC::default());
 
     zf_graph
         .add_static_source(
+            hlc,
             "camera-source".to_string(),
             ZFLinkId {
                 name: String::from(SOURCE),

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -1,270 +1,273 @@
-//
-// Copyright (c) 2017, 2021 ADLINK Technology Inc.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
-//
+// //
+// // Copyright (c) 2017, 2021 ADLINK Technology Inc.
+// //
+// // This program and the accompanying materials are made available under the
+// // terms of the Eclipse Public License 2.0 which is available at
+// // http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// // which is available at https://www.apache.org/licenses/LICENSE-2.0.
+// //
+// // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// //
+// // Contributors:
+// //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+// //
 
-use async_std::sync::{Arc, Mutex};
-use std::collections::HashMap;
-use zenoh_flow::model::link::{ZFFromEndpoint, ZFToEndpoint};
-use zenoh_flow::{
-    downcast, downcast_mut, get_input,
-    serde::{Deserialize, Serialize},
-    types::{
-        DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunResult, FutSinkResult,
-        InputRuleResult, RunResult, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
-        ZFInput, ZFLinkId, ZFResult,
-    },
-    zenoh_flow_derive::ZFState,
-    zf_data, zf_spin_lock,
-};
-use zenoh_flow_examples::ZFBytes;
+// use async_std::sync::{Arc, Mutex};
+// use std::collections::HashMap;
+// use zenoh_flow::model::link::{ZFFromEndpoint, ZFToEndpoint};
+// use zenoh_flow::{
+//     downcast, downcast_mut, get_input,
+//     serde::{Deserialize, Serialize},
+//     types::{
+//         DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunResult, FutSinkResult,
+//         InputRuleResult, RunResult, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
+//         ZFInput, ZFLinkId, ZFResult,
+//     },
+//     zenoh_flow_derive::ZFState,
+//     zf_data, zf_spin_lock,
+// };
+// use zenoh_flow_examples::ZFBytes;
 
-use opencv::{core, highgui, prelude::*, videoio};
+// use opencv::{core, highgui, prelude::*, videoio};
 
-static SOURCE: &str = "Frame";
-static INPUT: &str = "Frame";
+// static SOURCE: &str = "Frame";
+// static INPUT: &str = "Frame";
 
-#[derive(Debug)]
-struct CameraSource {
-    pub state: CameraState,
-}
+// #[derive(Debug)]
+// struct CameraSource {
+//     pub state: CameraState,
+// }
 
-#[derive(Clone)]
-struct InnerCameraAccess {
-    pub camera: Arc<Mutex<videoio::VideoCapture>>,
-    pub encode_options: Arc<Mutex<opencv::types::VectorOfi32>>,
-}
+// #[derive(Clone)]
+// struct InnerCameraAccess {
+//     pub camera: Arc<Mutex<videoio::VideoCapture>>,
+//     pub encode_options: Arc<Mutex<opencv::types::VectorOfi32>>,
+// }
 
-#[derive(Serialize, Deserialize, ZFState, Clone)]
-struct CameraState {
-    #[serde(skip_serializing, skip_deserializing)]
-    pub inner: Option<InnerCameraAccess>,
+// #[derive(Serialize, Deserialize, ZFState, Clone)]
+// struct CameraState {
+//     #[serde(skip_serializing, skip_deserializing)]
+//     pub inner: Option<InnerCameraAccess>,
 
-    pub resolution: (i32, i32),
-    pub delay: u64,
-}
+//     pub resolution: (i32, i32),
+//     pub delay: u64,
+// }
 
-// because of opencv
-impl std::fmt::Debug for CameraState {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "CameraState: resolution:{:?} delay:{:?}",
-            self.resolution, self.delay
-        )
-    }
-}
+// // because of opencv
+// impl std::fmt::Debug for CameraState {
+//     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+//         write!(
+//             f,
+//             "CameraState: resolution:{:?} delay:{:?}",
+//             self.resolution, self.delay
+//         )
+//     }
+// }
 
-impl CameraSource {
-    fn new() -> Self {
-        let mut camera = videoio::VideoCapture::new(0, videoio::CAP_ANY).unwrap(); // 0 is the default camera
-        let opened = videoio::VideoCapture::is_opened(&camera).unwrap();
-        if !opened {
-            panic!("Unable to open default camera!");
-        }
-        let mut encode_options = opencv::types::VectorOfi32::new();
-        encode_options.push(opencv::imgcodecs::IMWRITE_JPEG_QUALITY);
-        encode_options.push(90);
-        let inner = InnerCameraAccess {
-            camera: Arc::new(Mutex::new(camera)),
-            encode_options: Arc::new(Mutex::new(encode_options)),
-        };
+// impl CameraSource {
+//     fn new() -> Self {
+//         let mut camera = videoio::VideoCapture::new(0, videoio::CAP_ANY).unwrap(); // 0 is the default camera
+//         let opened = videoio::VideoCapture::is_opened(&camera).unwrap();
+//         if !opened {
+//             panic!("Unable to open default camera!");
+//         }
+//         let mut encode_options = opencv::types::VectorOfi32::new();
+//         encode_options.push(opencv::imgcodecs::IMWRITE_JPEG_QUALITY);
+//         encode_options.push(90);
+//         let inner = InnerCameraAccess {
+//             camera: Arc::new(Mutex::new(camera)),
+//             encode_options: Arc::new(Mutex::new(encode_options)),
+//         };
 
-        let state = CameraState {
-            inner: Some(inner),
-            resolution: (800, 600),
-            delay: 40,
-        };
+//         let state = CameraState {
+//             inner: Some(inner),
+//             resolution: (800, 600),
+//             delay: 40,
+//         };
 
-        Self { state }
-    }
+//         Self { state }
+//     }
 
-    async fn run_1(ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+//     async fn run_1(ctx: ZFContext) -> RunResult {
+//         let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
 
-        let mut guard = ctx.async_lock().await;
-        let mut _state = downcast_mut!(CameraState, guard.state).unwrap(); //downcasting to right type
+//         let mut guard = ctx.async_lock().await;
+//         let mut _state = downcast_mut!(CameraState, guard.state).unwrap(); //downcasting to right type
 
-        let inner = _state.inner.as_ref().unwrap();
+//         let inner = _state.inner.as_ref().unwrap();
 
-        let mut cam = zf_spin_lock!(inner.camera);
-        let encode_options = zf_spin_lock!(inner.encode_options);
+//         let mut cam = zf_spin_lock!(inner.camera);
+//         let encode_options = zf_spin_lock!(inner.encode_options);
 
-        let mut frame = core::Mat::default();
-        cam.read(&mut frame).unwrap();
+//         let mut frame = core::Mat::default();
+//         cam.read(&mut frame).unwrap();
 
-        let mut reduced = Mat::default();
-        opencv::imgproc::resize(
-            &frame,
-            &mut reduced,
-            opencv::core::Size::new(_state.resolution.0, _state.resolution.0),
-            0.0,
-            0.0,
-            opencv::imgproc::INTER_LINEAR,
-        )
-        .unwrap();
+//         let mut reduced = Mat::default();
+//         opencv::imgproc::resize(
+//             &frame,
+//             &mut reduced,
+//             opencv::core::Size::new(_state.resolution.0, _state.resolution.0),
+//             0.0,
+//             0.0,
+//             opencv::imgproc::INTER_LINEAR,
+//         )
+//         .unwrap();
 
-        let mut buf = opencv::types::VectorOfu8::new();
-        opencv::imgcodecs::imencode(".jpeg", &reduced, &mut buf, &encode_options).unwrap();
+//         let mut buf = opencv::types::VectorOfu8::new();
+//         opencv::imgcodecs::imencode(".jpeg", &reduced, &mut buf, &encode_options).unwrap();
 
-        let data = ZFBytes {
-            bytes: buf.to_vec(),
-        };
+//         let data = ZFBytes {
+//             bytes: buf.to_vec(),
+//         };
 
-        results.insert(String::from(SOURCE), zf_data!(data));
+//         results.insert(String::from(SOURCE), zf_data!(data));
 
-        async_std::task::sleep(std::time::Duration::from_millis(_state.delay));
+//         async_std::task::sleep(std::time::Duration::from_millis(_state.delay));
 
-        drop(cam);
-        drop(encode_options);
+//         drop(cam);
+//         drop(encode_options);
 
-        Ok(results)
-    }
-}
+//         Ok(results)
+//     }
+// }
 
-impl SourceTrait for CameraSource {
-    fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
-        Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) })
-    }
+// impl SourceTrait for CameraSource {
+//     fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
+//         Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) })
+//     }
 
-    fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
-        Box::new(zenoh_flow::default_output_rule)
-    }
+//     fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
+//         Box::new(zenoh_flow::default_output_rule)
+//     }
 
-    fn get_state(&self) -> Box<dyn StateTrait> {
-        Box::new(self.state.clone())
-    }
-}
+//     fn get_state(&self) -> Box<dyn StateTrait> {
+//         Box::new(self.state.clone())
+//     }
+// }
 
-#[derive(Debug)]
-struct VideoSink {
-    pub state: VideoState,
-}
+// #[derive(Debug)]
+// struct VideoSink {
+//     pub state: VideoState,
+// }
 
-#[derive(Serialize, Deserialize, ZFState, Clone, Debug)]
-struct VideoState {
-    pub window_name: String,
-}
+// #[derive(Serialize, Deserialize, ZFState, Clone, Debug)]
+// struct VideoState {
+//     pub window_name: String,
+// }
 
-impl VideoSink {
-    pub fn new() -> Self {
-        let window_name = &format!("Video-Sink");
-        highgui::named_window(window_name, 1).unwrap();
-        let state = VideoState {
-            window_name: window_name.to_string(),
-        };
-        Self { state }
-    }
+// impl VideoSink {
+//     pub fn new() -> Self {
+//         let window_name = &format!("Video-Sink");
+//         highgui::named_window(window_name, 1).unwrap();
+//         let state = VideoState {
+//             window_name: window_name.to_string(),
+//         };
+//         Self { state }
+//     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
-        if let Some(token) = inputs.get(INPUT) {
-            match token {
-                Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
-            }
-        } else {
-            Err(ZFError::MissingInput(String::from(INPUT)))
-        }
-    }
+//     pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+//         if let Some(token) = inputs.get(INPUT) {
+//             match token {
+//                 Token::Ready(_) => Ok(true),
+//                 Token::NotReady(_) => Ok(false),
+//             }
+//         } else {
+//             Err(ZFError::MissingInput(String::from(INPUT)))
+//         }
+//     }
 
-    pub async fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> ZFResult<()> {
-        let guard = ctx.async_lock().await; //getting state,
-        let _state = downcast!(VideoState, guard.state).unwrap(); //downcasting to right type
+//     pub async fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> ZFResult<()> {
+//         let guard = ctx.async_lock().await; //getting state,
+//         let _state = downcast!(VideoState, guard.state).unwrap(); //downcasting to right type
 
-        let data = get_input!(ZFBytes, String::from(INPUT), inputs).unwrap();
+//         let data = get_input!(ZFBytes, String::from(INPUT), inputs).unwrap();
 
-        let decoded = opencv::imgcodecs::imdecode(
-            &opencv::types::VectorOfu8::from_iter(data.bytes.clone()),
-            opencv::imgcodecs::IMREAD_COLOR,
-        )
-        .unwrap();
+//         let decoded = opencv::imgcodecs::imdecode(
+//             &opencv::types::VectorOfu8::from_iter(data.bytes.clone()),
+//             opencv::imgcodecs::IMREAD_COLOR,
+//         )
+//         .unwrap();
 
-        if decoded.size().unwrap().width > 0 {
-            highgui::imshow(&_state.window_name, &decoded).unwrap();
-        }
+//         if decoded.size().unwrap().width > 0 {
+//             highgui::imshow(&_state.window_name, &decoded).unwrap();
+//         }
 
-        highgui::wait_key(10).unwrap();
-        Ok(())
-    }
-}
+//         highgui::wait_key(10).unwrap();
+//         Ok(())
+//     }
+// }
 
-impl SinkTrait for VideoSink {
-    fn get_input_rule(&self, ctx: ZFContext) -> Box<FnInputRule> {
-        Box::new(Self::ir_1)
-    }
+// impl SinkTrait for VideoSink {
+//     fn get_input_rule(&self, ctx: ZFContext) -> Box<FnInputRule> {
+//         Box::new(Self::ir_1)
+//     }
 
-    fn get_run(&self, ctx: ZFContext) -> FnSinkRun {
-        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
-            Box::pin(Self::run_1(ctx, inputs))
-        })
-    }
+//     fn get_run(&self, ctx: ZFContext) -> FnSinkRun {
+//         Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
+//             Box::pin(Self::run_1(ctx, inputs))
+//         })
+//     }
 
-    fn get_state(&self) -> Box<dyn StateTrait> {
-        Box::new(self.state.clone())
-    }
-}
+//     fn get_state(&self) -> Box<dyn StateTrait> {
+//         Box::new(self.state.clone())
+//     }
+// }
 
-#[async_std::main]
-async fn main() {
-    let mut zf_graph = zenoh_flow::runtime::graph::DataFlowGraph::new();
+// #[async_std::main]
+// async fn main() {
+//     let mut zf_graph = zenoh_flow::runtime::graph::DataFlowGraph::new();
 
-    let source = Box::new(CameraSource::new());
-    let sink = Box::new(VideoSink::new());
+//     let source = Box::new(CameraSource::new());
+//     let sink = Box::new(VideoSink::new());
 
-    zf_graph
-        .add_static_source(
-            "camera-source".to_string(),
-            // "camera".to_string(),
-            String::from(SOURCE),
-            source,
-            None,
-        )
-        .unwrap();
+//     zf_graph
+//         .add_static_source(
+//             "camera-source".to_string(),
+//             // "camera".to_string(),
+//             String::from(SOURCE),
+//             source,
+//             None,
+//         )
+//         .unwrap();
 
-    zf_graph
-        .add_static_sink(
-            "video-sink".to_string(),
-            // "window".to_string(),
-            String::from(INPUT),
-            sink,
-            None,
-        )
-        .unwrap();
+//     zf_graph
+//         .add_static_sink(
+//             "video-sink".to_string(),
+//             // "window".to_string(),
+//             String::from(INPUT),
+//             sink,
+//             None,
+//         )
+//         .unwrap();
 
-    zf_graph
-        .add_link(
-            ZFFromEndpoint {
-                id: "camera-source".to_string(),
-                output: String::from(SOURCE),
-            },
-            ZFToEndpoint {
-                id: "video-sink".to_string(),
-                input: String::from(INPUT),
-            },
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+//     zf_graph
+//         .add_link(
+//             ZFFromEndpoint {
+//                 id: "camera-source".to_string(),
+//                 output: String::from(SOURCE),
+//             },
+//             ZFToEndpoint {
+//                 id: "video-sink".to_string(),
+//                 input: String::from(INPUT),
+//             },
+//             None,
+//             None,
+//             None,
+//         )
+//         .unwrap();
 
-    zf_graph.make_connections("local").await;
+//     zf_graph.make_connections("local").await;
 
-    let runners = zf_graph.get_runners();
-    for runner in runners {
-        async_std::task::spawn(async move {
-            let mut runner = runner.lock().await;
-            runner.run().await.unwrap();
-        });
-    }
+//     let runners = zf_graph.get_runners();
+//     for runner in runners {
+//         async_std::task::spawn(async move {
+//             let mut runner = runner.lock().await;
+//             runner.run().await.unwrap();
+//         });
+//     }
 
-    let () = std::future::pending().await;
+//     let () = std::future::pending().await;
+// }
+pub fn main(){
+    println!("hello world!");
 }

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -169,7 +169,7 @@ impl VideoSink {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))
@@ -219,9 +219,11 @@ async fn main() {
 
     let source = Box::new(CameraSource::new());
     let sink = Box::new(VideoSink::new());
+    let hlc = Arc::new(uhlc::HLC::default());
 
     zf_graph
         .add_static_source(
+            hlc,
             "camera-source".to_string(),
             // "camera".to_string(),
             String::from(SOURCE),

--- a/zenoh-flow-examples/examples/video-sink.rs
+++ b/zenoh-flow-examples/examples/video-sink.rs
@@ -19,7 +19,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnSinkRun, FutSinkResult, InputRuleResult, SinkTrait, StateTrait,
-        Token, ZFContext, ZFError, ZFInput, ZFLinkId, ZFResult,
+        Token, ZFContext, ZFError, ZFInput, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_empty_state, zf_spin_lock,

--- a/zenoh-flow-examples/examples/video-sink.rs
+++ b/zenoh-flow-examples/examples/video-sink.rs
@@ -49,7 +49,7 @@ impl VideoSink {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))

--- a/zenoh-flow-examples/examples/video-sink.rs
+++ b/zenoh-flow-examples/examples/video-sink.rs
@@ -45,7 +45,7 @@ impl VideoSink {
         Self {}
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -57,7 +57,7 @@ impl VideoSink {
     }
 
     pub async fn run_1(_ctx: ZFContext, mut inputs: ZFInput) -> ZFResult<()> {
-        let mut results: HashMap<ZFLinkId, Arc<dyn DataTrait>> = HashMap::new();
+        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let window_name = &format!("Video-Sink");
 

--- a/zenoh-flow-examples/examples/zenoh-sink.rs
+++ b/zenoh-flow-examples/examples/zenoh-sink.rs
@@ -19,7 +19,7 @@ use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
         DataTrait, FnInputRule, FnSinkRun, FutSinkResult, InputRuleResult, SinkTrait, StateTrait,
-        Token, ZFContext, ZFError, ZFInput, ZFLinkId, ZFResult,
+        Token, ZFContext, ZFError, ZFInput, ZFPortDescriptor, ZFResult,
     },
     zenoh_flow_derive::ZFState,
 };

--- a/zenoh-flow-examples/examples/zenoh-sink.rs
+++ b/zenoh-flow-examples/examples/zenoh-sink.rs
@@ -63,7 +63,7 @@ impl ExampleGenericZenohSink {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
-                Token::NotReady(_) => Ok(false),
+                Token::NotReady => Ok(false),
             }
         } else {
             Err(ZFError::MissingInput(String::from(INPUT)))

--- a/zenoh-flow-examples/examples/zenoh-sink.rs
+++ b/zenoh-flow-examples/examples/zenoh-sink.rs
@@ -30,7 +30,7 @@ use zenoh::net::config;
 use zenoh::net::{open, Session};
 use zenoh::ZFuture;
 
-static INPUT: &str = "Frame";
+static INPUT: &str = "Data";
 
 #[derive(Debug)]
 struct ExampleGenericZenohSink {
@@ -59,7 +59,7 @@ impl ExampleGenericZenohSink {
         }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<ZFLinkId, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),

--- a/zenoh-flow-examples/graphs/car-pipeline-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/car-pipeline-multi-runtime.yaml
@@ -3,10 +3,10 @@ operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
     inputs:
-      - name: Frame
+      - id: Frame
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image
     configuration:
       neural-network: /root/Workspace/experiments/yolov3-road.cfg
@@ -16,7 +16,7 @@ sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libvideo_file_source.dylib
     output:
-      name: Frame
+      id: Frame
       type: image
     configuration:
       file: /Users/gabri/Workspace/experiments/I2.mp4
@@ -25,21 +25,21 @@ sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame # Output
+    output_id : Frame # Output
   to:
     id : ObjectDetection
-    input : Frame # Input
+    input_id : Frame # Input
 - from:
     id : ObjectDetection
-    output : Frame
+    output_id : Frame
   to:
     id : Window
-    input : Frame
+    input_id : Frame
 
 
 mapping:

--- a/zenoh-flow-examples/graphs/car-pipeline-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/car-pipeline-multi-runtime.yaml
@@ -2,8 +2,12 @@ flow: CarVideoPipeline # it should have a id, from this we will have an Instance
 operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
-    inputs: [Frame]
-    outputs: [Frame] #port id = String
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
     configuration:
       neural-network: /root/Workspace/experiments/yolov3-road.cfg
       network-weights: /root/Workspace/experiments/yolov3-road.weights
@@ -11,14 +15,18 @@ operators:
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libvideo_file_source.dylib
-    output: Frame
+    output:
+      name: Frame
+      type: image
     configuration:
       file: /Users/gabri/Workspace/experiments/I2.mp4
       fps: 15
 sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
 links:
 - from:
     id : Camera0

--- a/zenoh-flow-examples/graphs/dnn-object-detection-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection-multi-runtime.yaml
@@ -2,8 +2,12 @@ flow: DNNPipeline # it should have a id, from this we will have an Instance of t
 operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
-    inputs: [Frame]
-    outputs: [Frame] #port id = String
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
     configuration:
       neural-network: /home/gabri/Workspace/experiments/yolov3-face.cfg
       network-weights: /home/gabri/Workspace/experiments/yolov3-wider_16000.weights
@@ -11,7 +15,9 @@ operators:
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
-    output: Frame
+    output:
+      name: Frame
+      type: image
     configuration:
       camera: /dev/video0
       resolution: 800x600
@@ -19,7 +25,9 @@ sources: # sources can have only ONE output
 sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
 links:
 - from:
     id : Camera0

--- a/zenoh-flow-examples/graphs/dnn-object-detection-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection-multi-runtime.yaml
@@ -3,10 +3,10 @@ operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
     inputs:
-      - name: Frame
+      - id: Frame
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image
     configuration:
       neural-network: /home/gabri/Workspace/experiments/yolov3-face.cfg
@@ -16,7 +16,7 @@ sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
     output:
-      name: Frame
+      id: Frame
       type: image
     configuration:
       camera: /dev/video0
@@ -26,21 +26,21 @@ sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame # Output
+    output_id : Frame # Output
   to:
     id : ObjectDetection
-    input : Frame # Input
+    input_id : Frame # Input
 - from:
     id : ObjectDetection
-    output : Frame
+    output_id : Frame
   to:
     id : Window
-    input : Frame
+    input_id : Frame
 
 
 mapping:

--- a/zenoh-flow-examples/graphs/dnn-object-detection.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection.yaml
@@ -3,10 +3,10 @@ operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
     inputs:
-      - name: Frame
+      - id: Frame
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image
     configuration:
       neural-network: /home/luca/Workspace/experiments/yolov3-face.cfg
@@ -16,7 +16,7 @@ sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
     output:
-      name: Frame
+      id: Frame
       type: image
     configuration:
       camera: /dev/video0
@@ -26,18 +26,18 @@ sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame # Output
+    output_id : Frame # Output
   to:
     id : ObjectDetection
-    input : Frame # Input
+    input_id : Frame # Input
 - from:
     id : ObjectDetection
-    output : Frame
+    output_id : Frame
   to:
     id : Window
-    input : Frame
+    input_id : Frame

--- a/zenoh-flow-examples/graphs/dnn-object-detection.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection.yaml
@@ -2,8 +2,12 @@ flow: DNNPipeline # it should have a id, from this we will have an Instance of t
 operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
-    inputs: [Frame]
-    outputs: [Frame] #port id = String
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
     configuration:
       neural-network: /home/luca/Workspace/experiments/yolov3-face.cfg
       network-weights: /home/luca/Workspace/experiments/yolov3-wider_16000.weights
@@ -11,7 +15,9 @@ operators:
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
-    output: Frame
+    output:
+      name: Frame
+      type: image
     configuration:
       camera: /dev/video0
       resolution: 800x600
@@ -19,7 +25,9 @@ sources: # sources can have only ONE output
 sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
 links:
 - from:
     id : Camera0

--- a/zenoh-flow-examples/graphs/dnn-object-detection.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection.yaml
@@ -2,8 +2,12 @@ flow: DNNPipeline # it should have a id, from this we will have an Instance of t
 operators:
   - id : ObjectDetection # this should be unique in the graph
     uri: file://./target/release/examples/libobject_detection_dnn.so
-    inputs: [Frame]
-    outputs: [Frame] #port id = String
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
     configuration:
       neural-network: /home/gabri/Workspace/experiments/yolov3-face.cfg
       network-weights: /home/gabri/Workspace/experiments/yolov3-wider_16000.weights
@@ -11,7 +15,9 @@ operators:
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
-    output: Frame
+    output:
+      name: Frame
+      type: image
     configuration:
       camera: /dev/video0
       resolution: 800x600
@@ -19,7 +25,9 @@ sources: # sources can have only ONE output
 sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
 links:
 - from:
     id : Camera0

--- a/zenoh-flow-examples/graphs/dnn-object-detection.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection.yaml
@@ -5,9 +5,9 @@ operators:
     inputs: [Frame]
     outputs: [Frame] #port id = String
     configuration:
-      neural-network: /home/gabri/Workspace/experiments/yolov3-face.cfg
-      network-weights: /home/gabri/Workspace/experiments/yolov3-wider_16000.weights
-      network-classes: /home/gabri/Workspace/experiments/face_classes.txt
+      neural-network: /home/luca/Workspace/experiments/yolov3-face.cfg
+      network-weights: /home/luca/Workspace/experiments/yolov3-wider_16000.weights
+      network-classes: /home/luca/Workspace/experiments/face_classes.txt
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so

--- a/zenoh-flow-examples/graphs/face-detection-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/face-detection-multi-runtime.yaml
@@ -2,8 +2,12 @@ flow: FacePipeline # it should have a id, from this we will have an Instance of 
 operators:
   - id : FaceDetection # this should be unique in the graph
     uri: file://./target/release/examples/libface_detection.so
-    inputs: [Frame]
-    outputs: [Frame] #port id = String
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
     # configuration:
       # neural-network: haarcascades/haarcascade_frontalface_alt_tree.xml
       # neural-network: haarcascades/haarcascade_eye.xml #eyes only
@@ -11,7 +15,9 @@ operators:
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
-    output: Frame
+    output:
+      name: Frame
+      type: image
     configuration:
       camera: /dev/video0
       resolution: 800x600
@@ -19,7 +25,9 @@ sources: # sources can have only ONE output
 sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
 links:
 - from:
     id : Camera0

--- a/zenoh-flow-examples/graphs/face-detection-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/face-detection-multi-runtime.yaml
@@ -3,10 +3,10 @@ operators:
   - id : FaceDetection # this should be unique in the graph
     uri: file://./target/release/examples/libface_detection.so
     inputs:
-      - name: Frame
+      - id: Frame
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image
     # configuration:
       # neural-network: haarcascades/haarcascade_frontalface_alt_tree.xml
@@ -16,7 +16,7 @@ sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
     output:
-      name: Frame
+      id: Frame
       type: image
     configuration:
       camera: /dev/video0
@@ -26,21 +26,21 @@ sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame # Output
+    output_id : Frame # Output
   to:
     id : FaceDetection
-    input : Frame # Input
+    input_id : Frame # Input
 - from:
     id : FaceDetection
-    output : Frame
+    output_id : Frame
   to:
     id : Window
-    input : Frame
+    input_id : Frame
 
 
 mapping:

--- a/zenoh-flow-examples/graphs/face_detection.yaml
+++ b/zenoh-flow-examples/graphs/face_detection.yaml
@@ -3,10 +3,10 @@ operators:
   - id : FaceDetection # this should be unique in the graph...
     uri: file://./target/release/examples/libface_detection.so
     inputs:
-      - name: Frame
+      - id: Frame
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image
     # configuration:
       # neural-network: haarcascades/haarcascade_frontalface_alt_tree.xml
@@ -16,7 +16,7 @@ sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
     output:
-      name: Frame
+      id: Frame
       type: image
     configuration:
       camera: /dev/video0
@@ -26,18 +26,18 @@ sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame # Output
+    output_id : Frame # Output
   to:
     id : FaceDetection
-    input : Frame # Input
+    input_id : Frame # Input
 - from:
     id : FaceDetection
-    output : Frame
+    output_id : Frame
   to:
     id : Window
-    input : Frame
+    input_id : Frame

--- a/zenoh-flow-examples/graphs/face_detection.yaml
+++ b/zenoh-flow-examples/graphs/face_detection.yaml
@@ -2,8 +2,12 @@ flow: FacePipeline # it should have a name, from this we will have an Instance o
 operators:
   - id : FaceDetection # this should be unique in the graph...
     uri: file://./target/release/examples/libface_detection.so
-    inputs: [Frame]
-    outputs: [Frame] #port id = String
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
     # configuration:
       # neural-network: haarcascades/haarcascade_frontalface_alt_tree.xml
       # neural-network: haarcascades/haarcascade_eye.xml #eyes only
@@ -11,7 +15,9 @@ operators:
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libcamera_source.so
-    output: Frame
+    output:
+      name: Frame
+      type: image
     configuration:
       camera: /dev/video0
       resolution: 800x600
@@ -19,7 +25,9 @@ sources: # sources can have only ONE output
 sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
 links:
 - from:
     id : Camera0

--- a/zenoh-flow-examples/graphs/fizz-buzz-multiple-runtimes.yaml
+++ b/zenoh-flow-examples/graphs/fizz-buzz-multiple-runtimes.yaml
@@ -3,23 +3,39 @@ flow: FizzBuzz
 operators:
   - id: FizzOperator
     uri: file://./target/debug/examples/libexample_fizz.dylib
-    inputs: [Int]
-    outputs: [Int, Str]
+    inputs:
+      - name: Int
+        type: u64
+    outputs:
+      - name: Int
+        type: u64
+      - name: Str
+        type: string
 
   - id: BuzzOperator
     uri: file://./target/debug/examples/libexample_buzz.dylib
-    inputs: [Int, Str]
-    outputs: [Str]
+    inputs:
+      - name: Int
+        type: u64
+      - name: Str
+        type: string
+    outputs:
+      - name: Str
+        type: string
 
 sources:
   - id: ManualSenderOperator
     uri: file://./target/debug/examples/libmanual_source.dylib
-    output: Int
+    output:
+      name: Int
+      type: u64
 
 sinks:
   - id: ReceiverOperator
     uri: file://./target/debug/examples/libgeneric_sink.dylib
-    input: Str
+    input:
+      name: Str
+      type: string
 
 links:
   - from:

--- a/zenoh-flow-examples/graphs/fizz-buzz-multiple-runtimes.yaml
+++ b/zenoh-flow-examples/graphs/fizz-buzz-multiple-runtimes.yaml
@@ -4,67 +4,67 @@ operators:
   - id: FizzOperator
     uri: file://./target/debug/examples/libexample_fizz.dylib
     inputs:
-      - name: Int
+      - id: Int
         type: u64
     outputs:
-      - name: Int
+      - id: Int
         type: u64
-      - name: Str
+      - id: Str
         type: string
 
   - id: BuzzOperator
     uri: file://./target/debug/examples/libexample_buzz.dylib
     inputs:
-      - name: Int
+      - id: Int
         type: u64
-      - name: Str
+      - id: Str
         type: string
     outputs:
-      - name: Str
+      - id: Str
         type: string
 
 sources:
   - id: ManualSenderOperator
     uri: file://./target/debug/examples/libmanual_source.dylib
     output:
-      name: Int
+      id: Int
       type: u64
 
 sinks:
   - id: ReceiverOperator
     uri: file://./target/debug/examples/libgeneric_sink.dylib
     input:
-      name: Str
+      id: Str
       type: string
 
 links:
   - from:
       id: ManualSenderOperator
-      output: Int
+      output_id: Int
     to:
       id: FizzOperator
-      input: Int
+      input_id: Int
 
   - from:
       id: FizzOperator
-      output: Int
+      output_id: Int
     to:
       id: BuzzOperator
-      input: Int
+      input_id: Int
 
   - from:
       id: FizzOperator
-      output: Str
+      output_id: Str
     to:
       id: BuzzOperator
-      input: Str
+      input_id: Str
 
   - from:
       id: BuzzOperator
-      output: Str
+      output_id: Str
     to:
       id: ReceiverOperator
-      input: Str
+      input_id: Str
 
 
 mapping:

--- a/zenoh-flow-examples/graphs/fizz_buzz_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/fizz_buzz_pipeline.yaml
@@ -3,22 +3,38 @@ flow: FizzBuzz
 operators:
   - id: FizzOperator
     uri: file://./target/debug/examples/libexample_fizz.dylib
-    inputs: [Int]
-    outputs: [Int, Str]
+    inputs:
+      - name: Int
+        type: u64
+    outputs:
+      - name: Int
+        type: u64
+      - name: Str
+        type: string
   - id: BuzzOperator
     uri: file://./target/debug/examples/libexample_buzz.dylib
-    inputs: [Int, Str]
-    outputs: [Str]
+    inputs:
+      - name: Int
+        type: u64
+      - name: Str
+        type: string
+    outputs:
+      - name: Str
+        type: string
 
 sources:
   - id: ManualSenderOperator
     uri: file://./target/debug/examples/libmanual_source.dylib
-    output: Int
+    output:
+      name: Int
+      type: u64
 
 sinks:
   - id: ReceiverOperator
     uri: file://./target/debug/examples/libgeneric_sink.dylib
-    input: Str
+    input:
+      name: Str
+      type: string
 
 links:
   - from:

--- a/zenoh-flow-examples/graphs/fizz_buzz_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/fizz_buzz_pipeline.yaml
@@ -4,63 +4,63 @@ operators:
   - id: FizzOperator
     uri: file://./target/debug/examples/libexample_fizz.dylib
     inputs:
-      - name: Int
+      - id: Int
         type: u64
     outputs:
-      - name: Int
+      - id: Int
         type: u64
-      - name: Str
+      - id: Str
         type: string
   - id: BuzzOperator
     uri: file://./target/debug/examples/libexample_buzz.dylib
     inputs:
-      - name: Int
+      - id: Int
         type: u64
-      - name: Str
+      - id: Str
         type: string
     outputs:
-      - name: Str
+      - id: Str
         type: string
 
 sources:
   - id: ManualSenderOperator
     uri: file://./target/debug/examples/libmanual_source.dylib
     output:
-      name: Int
+      id: Int
       type: u64
 
 sinks:
   - id: ReceiverOperator
     uri: file://./target/debug/examples/libgeneric_sink.dylib
     input:
-      name: Str
+      id: Str
       type: string
 
 links:
   - from:
       id: ManualSenderOperator
-      output: Int
+      output_id: Int
     to:
       id: FizzOperator
-      input: Int
+      input_id: Int
 
   - from:
       id: FizzOperator
-      output: Int
+      output_id: Int
     to:
       id: BuzzOperator
-      input: Int
+      input_id: Int
 
   - from:
       id: FizzOperator
-      output: Str
+      output_id: Str
     to:
       id: BuzzOperator
-      input: Str
+      input_id: Str
 
   - from:
       id: BuzzOperator
-      output: Str
+      output_id: Str
     to:
       id: ReceiverOperator
-      input: Str
+      input_id: Str

--- a/zenoh-flow-examples/graphs/random_source.yaml
+++ b/zenoh-flow-examples/graphs/random_source.yaml
@@ -3,15 +3,19 @@ operators: []
 sources:
   - id : RandomGenerator
     uri: file://./target/debug/examples/librandom_source.dylib
-    output: Number
+    output:
+        name: Random
+        type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/debug/examples/libgeneric_sink.dylib
-    input: Number
+    input:
+        name: Data
+        type: usize
 links:
 - from:
     id : RandomGenerator
-    output : Number
+    output : Random
   to:
     id : PrintSink
-    input : Number
+    input : Data

--- a/zenoh-flow-examples/graphs/random_source.yaml
+++ b/zenoh-flow-examples/graphs/random_source.yaml
@@ -4,18 +4,18 @@ sources:
   - id : RandomGenerator
     uri: file://./target/debug/examples/librandom_source.dylib
     output:
-        name: Random
+        id: Random
         type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/debug/examples/libgeneric_sink.dylib
     input:
-        name: Data
+        id: Data
         type: usize
 links:
 - from:
     id : RandomGenerator
-    output : Random
+    output_id : Random
   to:
     id : PrintSink
-    input : Data
+    input_id : Data

--- a/zenoh-flow-examples/graphs/simple_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/simple_pipeline.yaml
@@ -3,34 +3,34 @@ operators:
   - id : SumOperator
     uri: file://./target/debug/examples/libsum_and_send.dylib
     inputs:
-      - name: Number
+      - id: Number
         type: usize
     outputs:
-      - name: Sum
+      - id: Sum
         type: usize
 sources:
   - id : Counter
     uri: file://./target/debug/examples/libcounter_source.dylib
     output:
-      name: Counter
+      id: Counter
       type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/debug/examples/libgeneric_sink.dylib
     input:
-      name: Data
+      id: Data
       type: usize
 
 links:
 - from:
     id : Counter
-    output : Counter
+    output_id : Counter
   to:
     id : SumOperator
-    input : Number
+    input_id : Number
 - from:
     id : SumOperator
-    output : Sum
+    output_id : Sum
   to:
     id : PrintSink
-    input : Data
+    input_id : Data

--- a/zenoh-flow-examples/graphs/simple_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/simple_pipeline.yaml
@@ -2,26 +2,35 @@ flow: SimplePipeline
 operators:
   - id : SumOperator
     uri: file://./target/debug/examples/libsum_and_send.dylib
-    inputs: [Number]
-    outputs: [Number]
+    inputs:
+      - name: Number
+        type: usize
+    outputs:
+      - name: Sum
+        type: usize
 sources:
   - id : Counter
     uri: file://./target/debug/examples/libcounter_source.dylib
-    output: Number
+    output:
+      name: Counter
+      type: usize
 sinks:
   - id : PrintSink
     uri: file://./target/debug/examples/libgeneric_sink.dylib
-    input: Number
+    input:
+      name: Data
+      type: usize
+
 links:
 - from:
     id : Counter
-    output : Number
+    output : Counter
   to:
     id : SumOperator
     input : Number
 - from:
     id : SumOperator
-    output : Number
+    output : Sum
   to:
     id : PrintSink
-    input : Number
+    input : Data

--- a/zenoh-flow-examples/graphs/stereo-car-camera-pipeline.yaml
+++ b/zenoh-flow-examples/graphs/stereo-car-camera-pipeline.yaml
@@ -3,18 +3,18 @@ operators:
   - id : Concatenation # this should be unique in the graph
     uri: file://./target/release/examples/libframe_concat.so
     inputs:
-      - name: Frame1
+      - id: Frame1
         type: image
-      - name: Frame2
+      - id: Frame2
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image  #port id = String
 sources: # sources can have only ONE output
   - id : Camera0
     uri: file://./target/release/examples/libvideo_file_source.so
     output:
-        name: Frame
+        id: Frame
         type: image
     configuration:
       file: /home/luca/Workspace/experiments/I2.mp4
@@ -22,7 +22,7 @@ sources: # sources can have only ONE output
   - id : Camera1
     uri: file://./target/release/examples/libvideo_file_source.so
     output:
-        name: Frame
+        id: Frame
         type: image
     configuration:
       file: /home/luca/Workspace/experiments/I1.mp4
@@ -31,24 +31,24 @@ sinks: # sources can have only ONE input
   - id : Window
     uri: file://./target/release/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame # Output
+    output_id : Frame # Output
   to:
     id : Concatenation
-    input : Frame1 # Input
+    input_id : Frame1 # Input
 - from:
     id : Camera1
-    output : Frame
+    output_id : Frame
   to:
     id : Concatenation
-    input : Frame2
+    input_id : Frame2
 - from:
       id: Concatenation
-      output: Frame
+      output_id : Frame
   to:
       id: Window
-      input: Frame
+      input_id : Frame

--- a/zenoh-flow-examples/graphs/stereo-car-camera-pipeline.yaml
+++ b/zenoh-flow-examples/graphs/stereo-car-camera-pipeline.yaml
@@ -1,0 +1,54 @@
+flow: CarVisionPipeline # it should have a id, from this we will have an Instance of the graph, UUID => flow
+operators:
+  - id : Concatenation # this should be unique in the graph
+    uri: file://./target/release/examples/libframe_concat.so
+    inputs:
+      - name: Frame1
+        type: image
+      - name: Frame2
+        type: image
+    outputs:
+      - name: Frame
+        type: image  #port id = String
+sources: # sources can have only ONE output
+  - id : Camera0
+    uri: file://./target/release/examples/libvideo_file_source.so
+    output:
+        name: Frame
+        type: image
+    configuration:
+      file: /home/luca/Workspace/experiments/I2.mp4
+      fps: 15
+  - id : Camera1
+    uri: file://./target/release/examples/libvideo_file_source.so
+    output:
+        name: Frame
+        type: image
+    configuration:
+      file: /home/luca/Workspace/experiments/I1.mp4
+      fps: 15
+sinks: # sources can have only ONE input
+  - id : Window
+    uri: file://./target/release/examples/libvideo_sink.so
+    input:
+      name: Frame
+      type: image
+links:
+- from:
+    id : Camera0
+    output : Frame # Output
+  to:
+    id : Concatenation
+    input : Frame1 # Input
+- from:
+    id : Camera1
+    output : Frame
+  to:
+    id : Concatenation
+    input : Frame2
+- from:
+      id: Concatenation
+      output: Frame
+  to:
+      id: Window
+      input: Frame

--- a/zenoh-flow-examples/graphs/video_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/video_pipeline.yaml
@@ -4,19 +4,19 @@ sources:
   - id : Camera
     uri: file://./target/debug/examples/libcamera_source.so
     output:
-      name: Frame
+      id: Frame
       type: image
 sinks:
   - id : Window
     uri: file://./target/debug/examples/libvideo_sink.so
     input:
-      name: Frame
+      id: Frame
       type: image
 
 links:
 - from:
     id : Camera
-    output : Frame
+    output_id : Frame
   to:
     id : Window
-    input : Frame
+    input_id : Frame

--- a/zenoh-flow-examples/graphs/video_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/video_pipeline.yaml
@@ -3,11 +3,16 @@ operators: []
 sources:
   - id : Camera
     uri: file://./target/debug/examples/libcamera_source.so
-    output: Frame
+    output:
+      name: Frame
+      type: image
 sinks:
   - id : Window
     uri: file://./target/debug/examples/libvideo_sink.so
-    input: Frame
+    input:
+      name: Frame
+      type: image
+
 links:
 - from:
     id : Camera

--- a/zenoh-flow-examples/graphs/zface_detection.yaml
+++ b/zenoh-flow-examples/graphs/zface_detection.yaml
@@ -3,33 +3,33 @@ operators:
   - id : FaceDetection
     uri: file://./target/debug/examples/libface_detection.dylib
     inputs:
-      - name: Frame
+      - id: Frame
         type: image
     outputs:
-      - name: Frame
+      - id: Frame
         type: image
 sources:
   - id : Camera0
     uri: file://./target/debug/examples/libcamera_source.dylib
     output:
-      name: Frame
+      id: Frame
       type: image
 sinks:
   - id : ZSink
     uri: file://./target/debug/examples/libzenoh_sink.dylib
     input:
-      name: Data
+      id: Data
       type: image
 links:
 - from:
     id : Camera0
-    output : Frame
+    output_id : Frame
   to:
     id : FaceDetection
-    input : Frame
+    input_id : Frame
 - from:
     id : FaceDetection
-    output : Frame
+    output_id : Frame
   to:
     id : ZSink
-    input : Data
+    input_id : Data

--- a/zenoh-flow-examples/graphs/zface_detection.yaml
+++ b/zenoh-flow-examples/graphs/zface_detection.yaml
@@ -2,16 +2,24 @@ flow: zface-detection
 operators:
   - id : FaceDetection
     uri: file://./target/debug/examples/libface_detection.dylib
-    inputs: [Frame]
-    outputs: [Frame]
+    inputs:
+      - name: Frame
+        type: image
+    outputs:
+      - name: Frame
+        type: image
 sources:
   - id : Camera0
     uri: file://./target/debug/examples/libcamera_source.dylib
-    output: Frame
+    output:
+      name: Frame
+      type: image
 sinks:
   - id : ZSink
     uri: file://./target/debug/examples/libzenoh_sink.dylib
-    input: Frame
+    input:
+      name: Data
+      type: image
 links:
 - from:
     id : Camera0
@@ -24,4 +32,4 @@ links:
     output : Frame
   to:
     id : ZSink
-    input : Frame
+    input : Data

--- a/zenoh-flow-examples/graphs/zvideo_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/zvideo_pipeline.yaml
@@ -4,18 +4,18 @@ sources:
   - id : Camera
     uri: file://./target/debug/examples/libcamera_source.dylib
     output:
-      name: Frame
+      id: Frame
       type: image
 sinks:
   - id : ZSink
     uri: file://./target/debug/examples/libzenoh_sink.dylib
     input:
-      name: Data
+      id: Data
       type: image
 links:
 - from:
     id : Camera
-    output : Frame
+    output_id : Frame
   to:
     id : ZSink
-    input : Data
+    input_id : Data

--- a/zenoh-flow-examples/graphs/zvideo_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/zvideo_pipeline.yaml
@@ -3,15 +3,19 @@ operators: []
 sources:
   - id : Camera
     uri: file://./target/debug/examples/libcamera_source.dylib
-    output: Frame
+    output:
+      name: Frame
+      type: image
 sinks:
   - id : ZSink
     uri: file://./target/debug/examples/libzenoh_sink.dylib
-    input: Frame
+    input:
+      name: Data
+      type: image
 links:
 - from:
     id : Camera
     output : Frame
   to:
     id : ZSink
-    input : Frame
+    input : Data

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -30,6 +30,7 @@ zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master",
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 url = "2.2.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", branch = "master" }
 futures = "0.3.15"
 async-std = { version = "=1.9.0", features = ["attributes"] }
 async-trait = "0.1.50"

--- a/zenoh-flow/src/bin/runtime.rs
+++ b/zenoh-flow/src/bin/runtime.rs
@@ -54,7 +54,7 @@ async fn main() {
     let dfr =
         zenoh_flow::model::dataflow::DataFlowRecord::from_dataflow_descriptor(mapped).unwrap();
 
-    //write_record_to_file(dfr.clone(), "computed-record.yaml");
+    _write_record_to_file(dfr.clone(), "computed-record.yaml");
 
     // creating graph
     let mut dataflow_graph =

--- a/zenoh-flow/src/model/connector.rs
+++ b/zenoh-flow/src/model/connector.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::serde::{Deserialize, Serialize};
-use crate::{ZFLinkId, ZFRuntimeID};
+use crate::{ZFPortDescriptor, ZFRuntimeID};
 
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub enum ZFConnectorKind {
@@ -35,7 +35,7 @@ pub struct ZFConnectorRecord {
     pub kind: ZFConnectorKind,
     pub id: String,
     pub resource: String,
-    pub link_id: ZFLinkId,
+    pub link_id: ZFPortDescriptor,
     pub runtime: ZFRuntimeID,
 }
 

--- a/zenoh-flow/src/model/dataflow.rs
+++ b/zenoh-flow/src/model/dataflow.rs
@@ -20,7 +20,7 @@ use crate::model::operator::{
 };
 use crate::runtime::graph::node::DataFlowNode;
 use crate::serde::{Deserialize, Serialize};
-use crate::types::{ZFError, ZFOperatorId, ZFResult, ZFRuntimeID, ZFLinkId};
+use crate::types::{ZFError, ZFLinkId, ZFOperatorId, ZFResult, ZFRuntimeID};
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -212,7 +212,12 @@ impl DataFlowRecord {
 
             let from_type = match self.find_component_output_type(&l.from.id, &l.from.output) {
                 Some(t) => t,
-                None => return Err(ZFError::PortNotFound((l.from.id.clone(), l.from.output.clone()))),
+                None => {
+                    return Err(ZFError::PortNotFound((
+                        l.from.id.clone(),
+                        l.from.output.clone(),
+                    )))
+                }
             };
 
             let to_type = match self.find_component_input_type(&l.to.id, &l.to.input) {

--- a/zenoh-flow/src/model/dataflow.rs
+++ b/zenoh-flow/src/model/dataflow.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::model::connector::{ZFConnectorKind, ZFConnectorRecord};
-use crate::model::link::{ZFFromEndpoint, ZFLinkDescriptor, ZFToEndpoint};
+use crate::model::link::{ZFLinkDescriptor, ZFPortFrom, ZFPortTo};
 use crate::model::operator::{
     ZFOperatorDescriptor, ZFOperatorRecord, ZFSinkDescriptor, ZFSinkRecord, ZFSourceDescriptor,
     ZFSourceRecord,
@@ -279,7 +279,7 @@ impl DataFlowRecord {
                     // creating link between component and sender
                     let link_sender = ZFLinkDescriptor {
                         from: l.from.clone(),
-                        to: ZFToEndpoint {
+                        to: ZFPortTo {
                             id: sender_id,
                             input_id: l.from.output_id.clone(),
                         },
@@ -312,7 +312,7 @@ impl DataFlowRecord {
 
                 //creating link between receiver and component
                 let link_receiver = ZFLinkDescriptor {
-                    from: ZFFromEndpoint {
+                    from: ZFPortFrom {
                         id: receiver_id,
                         output_id: l.to.input_id.clone(),
                     },

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -12,7 +12,7 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use crate::{types::ZFLinkId, ZFOperatorId};
+use crate::ZFOperatorId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -27,11 +27,11 @@ pub struct ZFLinkDescriptor {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFFromEndpoint {
     pub id: ZFOperatorId,
-    pub output: String,
+    pub output_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFToEndpoint {
     pub id: ZFOperatorId,
-    pub input: String,
+    pub input_id: String,
 }

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -27,11 +27,11 @@ pub struct ZFLinkDescriptor {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFFromEndpoint {
     pub id: ZFOperatorId,
-    pub output: ZFLinkId,
+    pub output: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFToEndpoint {
     pub id: ZFOperatorId,
-    pub input: ZFLinkId,
+    pub input: String,
 }

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -17,21 +17,21 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFLinkDescriptor {
-    pub from: ZFFromEndpoint,
-    pub to: ZFToEndpoint,
+    pub from: ZFPortFrom,
+    pub to: ZFPortTo,
     pub size: Option<usize>,
     pub queueing_policy: Option<String>,
     pub priority: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ZFFromEndpoint {
+pub struct ZFPortFrom {
     pub id: ZFOperatorId,
     pub output_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ZFToEndpoint {
+pub struct ZFPortTo {
     pub id: ZFOperatorId,
     pub input_id: String,
 }

--- a/zenoh-flow/src/model/operator.rs
+++ b/zenoh-flow/src/model/operator.rs
@@ -81,6 +81,16 @@ impl std::fmt::Display for ZFSinkRecord {
     }
 }
 
+impl ZFSinkRecord {
+    pub fn get_input_type(&self, id: &str) -> Option<String> {
+        if self.input.name == *id {
+            return Some(self.input.type_name.clone());
+        } else {
+            return None;
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFSourceRecord {
     pub id: ZFOperatorId,
@@ -93,6 +103,16 @@ pub struct ZFSourceRecord {
 impl std::fmt::Display for ZFSourceRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{} - Kind: Source", self.id)
+    }
+}
+
+impl ZFSourceRecord {
+    pub fn get_output_type(&self, id: &str) -> Option<String> {
+        if self.output.name == *id {
+            return Some(self.output.type_name.clone());
+        } else {
+            return None;
+        }
     }
 }
 
@@ -109,5 +129,21 @@ pub struct ZFOperatorRecord {
 impl std::fmt::Display for ZFOperatorRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{} - Kind: Operator", self.id)
+    }
+}
+
+impl ZFOperatorRecord {
+    pub fn get_output_type(&self, id: &str) -> Option<String> {
+        match self.outputs.iter().find(|&lid| *lid.name == *id) {
+            Some(lid) => Some(lid.type_name.clone()),
+            None => None,
+        }
+    }
+
+    pub fn get_input_type(&self, id: &str) -> Option<String> {
+        match self.inputs.iter().find(|&lid| *lid.name == *id) {
+            Some(lid) => Some(lid.type_name.clone()),
+            None => None,
+        }
     }
 }

--- a/zenoh-flow/src/model/operator.rs
+++ b/zenoh-flow/src/model/operator.rs
@@ -12,7 +12,7 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use crate::types::{ZFLinkId, ZFOperatorId, ZFRuntimeID};
+use crate::types::{ZFOperatorId, ZFPortDescriptor, ZFRuntimeID};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFSinkDescriptor {
     pub id: ZFOperatorId,
-    pub input: ZFLinkId,
+    pub input: ZFPortDescriptor,
     pub uri: Option<String>,
     pub configuration: Option<HashMap<String, String>>,
     pub runtime: Option<ZFRuntimeID>, // to be removed
@@ -36,7 +36,7 @@ impl std::fmt::Display for ZFSinkDescriptor {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFSourceDescriptor {
     pub id: ZFOperatorId,
-    pub output: ZFLinkId,
+    pub output: ZFPortDescriptor,
     pub uri: Option<String>,
     pub configuration: Option<HashMap<String, String>>,
     pub runtime: Option<ZFRuntimeID>, // to be removed
@@ -51,8 +51,8 @@ impl std::fmt::Display for ZFSourceDescriptor {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFOperatorDescriptor {
     pub id: ZFOperatorId,
-    pub inputs: Vec<ZFLinkId>,
-    pub outputs: Vec<ZFLinkId>,
+    pub inputs: Vec<ZFPortDescriptor>,
+    pub outputs: Vec<ZFPortDescriptor>,
     pub uri: Option<String>,
     pub configuration: Option<HashMap<String, String>>,
     pub runtime: Option<ZFRuntimeID>, // to be removed
@@ -69,7 +69,7 @@ impl std::fmt::Display for ZFOperatorDescriptor {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFSinkRecord {
     pub id: ZFOperatorId,
-    pub input: ZFLinkId,
+    pub input: ZFPortDescriptor,
     pub uri: Option<String>,
     pub configuration: Option<HashMap<String, String>>,
     pub runtime: ZFRuntimeID,
@@ -83,8 +83,8 @@ impl std::fmt::Display for ZFSinkRecord {
 
 impl ZFSinkRecord {
     pub fn get_input_type(&self, id: &str) -> Option<String> {
-        if self.input.name == *id {
-            return Some(self.input.type_name.clone());
+        if self.input.port_id == *id {
+            return Some(self.input.port_type.clone());
         } else {
             return None;
         }
@@ -94,7 +94,7 @@ impl ZFSinkRecord {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFSourceRecord {
     pub id: ZFOperatorId,
-    pub output: ZFLinkId,
+    pub output: ZFPortDescriptor,
     pub uri: Option<String>,
     pub configuration: Option<HashMap<String, String>>,
     pub runtime: ZFRuntimeID,
@@ -108,8 +108,8 @@ impl std::fmt::Display for ZFSourceRecord {
 
 impl ZFSourceRecord {
     pub fn get_output_type(&self, id: &str) -> Option<String> {
-        if self.output.name == *id {
-            return Some(self.output.type_name.clone());
+        if self.output.port_id == *id {
+            return Some(self.output.port_type.clone());
         } else {
             return None;
         }
@@ -119,8 +119,8 @@ impl ZFSourceRecord {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFOperatorRecord {
     pub id: ZFOperatorId,
-    pub inputs: Vec<ZFLinkId>,
-    pub outputs: Vec<ZFLinkId>,
+    pub inputs: Vec<ZFPortDescriptor>,
+    pub outputs: Vec<ZFPortDescriptor>,
     pub uri: Option<String>,
     pub configuration: Option<HashMap<String, String>>,
     pub runtime: ZFRuntimeID,
@@ -134,15 +134,15 @@ impl std::fmt::Display for ZFOperatorRecord {
 
 impl ZFOperatorRecord {
     pub fn get_output_type(&self, id: &str) -> Option<String> {
-        match self.outputs.iter().find(|&lid| *lid.name == *id) {
-            Some(lid) => Some(lid.type_name.clone()),
+        match self.outputs.iter().find(|&lid| *lid.port_id == *id) {
+            Some(lid) => Some(lid.port_type.clone()),
             None => None,
         }
     }
 
     pub fn get_input_type(&self, id: &str) -> Option<String> {
-        match self.inputs.iter().find(|&lid| *lid.name == *id) {
-            Some(lid) => Some(lid.type_name.clone()),
+        match self.inputs.iter().find(|&lid| *lid.port_id == *id) {
+            Some(lid) => Some(lid.port_type.clone()),
             None => None,
         }
     }

--- a/zenoh-flow/src/runtime/connectors.rs
+++ b/zenoh-flow/src/runtime/connectors.rs
@@ -44,7 +44,7 @@ impl ZFZenohSender {
             while let Ok((_, msg)) = input.recv().await {
                 log::debug!("ZenohSender IN <= {:?} ", msg);
 
-                let serialized = match &msg.msg {
+                let serialized = match &msg.message {
                     Message::Data(data_msg) => match data_msg {
                         ZFDataMessage::Deserialized(de) => {
                             let se = Arc::new(
@@ -52,8 +52,8 @@ impl ZFZenohSender {
                                     .map_err(|_| ZFError::SerializationError)?,
                             );
                             let se_msg = ZFMessage {
-                                ts: msg.ts,
-                                msg: Message::Data(ZFDataMessage::new_serialized(se)),
+                                timestamp: msg.timestamp.clone(),
+                                message: Message::Data(ZFDataMessage::new_serialized(se)),
                             };
                             bincode::serialize(&se_msg).map_err(|_| ZFError::SerializationError)?
                         }

--- a/zenoh-flow/src/runtime/graph/link.rs
+++ b/zenoh-flow/src/runtime/graph/link.rs
@@ -14,7 +14,6 @@
 
 use async_std::sync::Arc;
 
-use crate::types::ZFLinkId;
 use crate::ZFResult;
 
 #[derive(Clone, Debug)]
@@ -31,7 +30,7 @@ pub struct ZFLinkReceiver<T> {
 }
 
 impl<T: std::marker::Send + std::marker::Sync> ZFLinkReceiver<T> {
-    // pub async fn peek(&mut self) -> ZFResult<(ZFLinkId, Arc<T>)> {
+    // pub async fn peek(&mut self) -> ZFResult<(String, Arc<T>)> {
     //     match &self.last_message {
     //         Some(message) => Ok((self.id, message.clone())),
     //         None => {

--- a/zenoh-flow/src/runtime/graph/mod.rs
+++ b/zenoh-flow/src/runtime/graph/mod.rs
@@ -32,7 +32,7 @@ use crate::runtime::message::ZFMessage;
 use crate::runtime::runner::{Runner, ZFOperatorRunner, ZFSinkRunner, ZFSourceRunner};
 use crate::{
     model::connector::ZFConnectorKind,
-    model::link::{ZFFromEndpoint, ZFLinkDescriptor, ZFToEndpoint},
+    model::link::{ZFLinkDescriptor, ZFPortFrom, ZFPortTo},
     model::operator::{ZFOperatorRecord, ZFSinkRecord, ZFSourceRecord},
     runtime::graph::link::link,
     runtime::graph::node::DataFlowNodeKind,
@@ -264,8 +264,8 @@ impl DataFlowGraph {
 
     pub fn add_link(
         &mut self,
-        from: ZFFromEndpoint,
-        to: ZFToEndpoint,
+        from: ZFPortFrom,
+        to: ZFPortTo,
         size: Option<usize>,
         queueing_policy: Option<String>,
         priority: Option<usize>,

--- a/zenoh-flow/src/runtime/graph/mod.rs
+++ b/zenoh-flow/src/runtime/graph/mod.rs
@@ -171,7 +171,10 @@ impl DataFlowGraph {
     }
 
     pub fn to_dot_notation(&self) -> String {
-        format!("{:?}", Dot::with_config(&self.graph, &[Config::EdgeNoLabel]))
+        format!(
+            "{:?}",
+            Dot::with_config(&self.graph, &[Config::EdgeNoLabel])
+        )
     }
 
     pub fn add_static_operator(
@@ -252,71 +255,73 @@ impl DataFlowGraph {
         Ok(())
     }
 
-    // pub fn add_link(
-    //     &mut self,
-    //     from: ZFFromEndpoint,
-    //     to: ZFToEndpoint,
-    //     size: Option<usize>,
-    //     queueing_policy: Option<String>,
-    //     priority: Option<usize>,
-    // ) -> ZFResult<()> {
-    //     let connection = ZFLinkDescriptor {
-    //         from,
-    //         to,
-    //         size,
-    //         queueing_policy,
-    //         priority,
-    //     };
+    pub fn add_link(
+        &mut self,
+        from: ZFFromEndpoint,
+        to: ZFToEndpoint,
+        size: Option<usize>,
+        queueing_policy: Option<String>,
+        priority: Option<usize>,
+    ) -> ZFResult<()> {
+        let connection = ZFLinkDescriptor {
+            from,
+            to,
+            size,
+            queueing_policy,
+            priority,
+        };
 
-    //     if connection.from.output == connection.to.input {
-    //         let from_index = match self
-    //             .operators
-    //             .iter()
-    //             .find(|&(_, o)| o.get_id() == connection.from.id.clone())
-    //         {
-    //             Some((idx, op)) => match op.has_output(connection.from.output.clone()) {
-    //                 true => idx,
-    //                 false => {
-    //                     return Err(ZFError::PortNotFound((
-    //                         connection.from.id.clone(),
-    //                         connection.from.output.clone(),
-    //                     )))
-    //                 }
-    //             },
-    //             None => return Err(ZFError::OperatorNotFound(connection.from.id.clone())),
-    //         };
+        let (from_index, from_type) = match self
+            .operators
+            .iter()
+            .find(|&(_, o)| o.get_id() == connection.from.id.clone())
+        {
+            Some((idx, op)) => match op.has_output(connection.from.output.clone()) {
+                true => (idx, op.get_output_type(connection.from.output.clone())?),
+                false => {
+                    return Err(ZFError::PortNotFound((
+                        connection.from.id.clone(),
+                        connection.from.output.clone(),
+                    )))
+                }
+            },
+            None => return Err(ZFError::OperatorNotFound(connection.from.id.clone())),
+        };
 
-    //         let to_index = match self
-    //             .operators
-    //             .iter()
-    //             .find(|&(_, o)| o.get_id() == connection.to.id.clone())
-    //         {
-    //             Some((idx, op)) => match op.has_input(connection.to.input.clone()) {
-    //                 true => idx,
-    //                 false => {
-    //                     return Err(ZFError::PortNotFound((
-    //                         connection.to.id.clone(),
-    //                         connection.to.input.clone(),
-    //                     )))
-    //                 }
-    //             },
-    //             None => return Err(ZFError::OperatorNotFound(connection.to.id.clone())),
-    //         };
+        let (to_index, to_type) = match self
+            .operators
+            .iter()
+            .find(|&(_, o)| o.get_id() == connection.to.id.clone())
+        {
+            Some((idx, op)) => match op.has_input(connection.to.input.clone()) {
+                true => (idx, op.get_input_type(connection.to.input.clone())?),
+                false => {
+                    return Err(ZFError::PortNotFound((
+                        connection.to.id.clone(),
+                        connection.to.input.clone(),
+                    )))
+                }
+            },
+            None => return Err(ZFError::OperatorNotFound(connection.to.id.clone())),
+        };
 
-    //         self.links.push((
-    //             self.graph
-    //                 .add_edge(*from_index, *to_index, connection.from.output.clone()),
-    //             connection,
-    //         ));
-    //     } else {
-    //         return Err(ZFError::PortIdNotMatching((
-    //             connection.from.output.clone(),
-    //             connection.to.input,
-    //         )));
-    //     }
+        if from_type == to_type {
+            self.links.push((
+                self.graph.add_edge(
+                    *from_index,
+                    *to_index,
+                    (connection.from.output.clone(), connection.to.input.clone()),
+                ),
+                connection,
+            ));
+            return Ok(());
+        }
 
-    //     Ok(())
-    // }
+        return Err(ZFError::PortTypeNotMatching((
+            String::from(from_type),
+            String::from(to_type),
+        )));
+    }
 
     pub fn load(&mut self, runtime: &str) -> ZFResult<()> {
         let session = Arc::new(zenoh::net::open(zenoh::net::config::peer()).wait()?);
@@ -424,12 +429,12 @@ impl DataFlowGraph {
                         .find(|&(edge_index, _)| *edge_index == down_edge_index)
                         .ok_or(ZFError::OperatorNotFound(up_op.get_id().clone()))?;
 
-                        let (link_id_from, link_id_to) = match self.graph.edge_weight(down_edge_index) {
-                            Some(w) => w,
-                            None => return Err(ZFError::GenericError),
-                        };
+                    let (link_id_from, link_id_to) = match self.graph.edge_weight(down_edge_index) {
+                        Some(w) => w,
+                        None => return Err(ZFError::GenericError),
+                    };
 
-                        //let link_id  = down_link.from.output.clone();
+                    //let link_id  = down_link.from.output.clone();
 
                     let down_op = match self
                         .operators
@@ -453,7 +458,11 @@ impl DataFlowGraph {
                         link_id_from,
                         link_id_to,
                     );
-                    let (tx, rx) = link::<ZFMessage>(None, String::from(link_id_from), String::from(link_id_to));
+                    let (tx, rx) = link::<ZFMessage>(
+                        None,
+                        String::from(link_id_from),
+                        String::from(link_id_to),
+                    );
 
                     up_runner.add_output(tx);
                     down_runner.add_input(rx);

--- a/zenoh-flow/src/runtime/graph/mod.rs
+++ b/zenoh-flow/src/runtime/graph/mod.rs
@@ -44,7 +44,7 @@ pub struct DataFlowGraph {
     pub flow: String,
     pub operators: Vec<(NodeIndex, DataFlowNode)>,
     pub links: Vec<(EdgeIndex, ZFLinkDescriptor)>,
-    pub graph: StableGraph<DataFlowNode, ZFLinkId>,
+    pub graph: StableGraph<DataFlowNode, (String, String)>,
     pub operators_runners: HashMap<ZFOperatorName, (Arc<Mutex<Runner>>, DataFlowNodeKind)>,
 }
 
@@ -55,13 +55,13 @@ impl DataFlowGraph {
             flow: "".to_string(),
             operators: Vec::new(),
             links: Vec::new(),
-            graph: StableGraph::<DataFlowNode, ZFLinkId>::new(),
+            graph: StableGraph::<DataFlowNode, (String, String)>::new(),
             operators_runners: HashMap::new(),
         }
     }
 
     pub fn from_dataflow_record(dr: DataFlowRecord) -> ZFResult<Self> {
-        let mut graph = StableGraph::<DataFlowNode, ZFLinkId>::new();
+        let mut graph = StableGraph::<DataFlowNode, (String, String)>::new();
         let mut operators = Vec::new();
         let mut links: Vec<(EdgeIndex, ZFLinkDescriptor)> = Vec::new();
         for o in dr.operators {
@@ -94,35 +94,56 @@ impl DataFlowGraph {
 
         for l in dr.links {
             // First check if the LinkId are the same
-            if l.from.output != l.to.input {
-                return Err(ZFError::PortIdNotMatching((
-                    l.from.output.clone(),
-                    l.to.input,
-                )));
-            }
+            // if l.from.output != l.to.input {
+            //     return Err(ZFError::PortIdNotMatching((
+            //         l.from.output.clone(),
+            //         l.to.input,
+            //     )));
+            // }
 
-            let (from_index, from_runtime) =
-                match operators.iter().find(|&(_, o)| o.get_id() == l.from.id) {
-                    Some((idx, op)) => match op.has_output(l.from.output.clone()) {
-                        true => (idx, op.get_runtime()),
-                        false => return Err(ZFError::PortNotFound((l.from.id, l.from.output))),
-                    },
-                    None => return Err(ZFError::OperatorNotFound(l.from.id)),
-                };
+            let (from_index, from_runtime, from_type) = match operators
+                .iter()
+                .find(|&(_, o)| o.get_id() == l.from.id)
+            {
+                Some((idx, op)) => match op.has_output(l.from.output.clone()) {
+                    true => (
+                        idx,
+                        op.get_runtime(),
+                        op.get_output_type(l.from.output.clone())?,
+                    ),
+                    false => return Err(ZFError::PortNotFound((l.from.id, l.from.output.clone()))),
+                },
+                None => return Err(ZFError::OperatorNotFound(l.from.id)),
+            };
 
-            let (to_index, to_runtime) =
+            let (to_index, to_runtime, to_type) =
                 match operators.iter().find(|&(_, o)| o.get_id() == l.to.id) {
                     Some((idx, op)) => match op.has_input(l.to.input.clone()) {
-                        true => (idx, op.get_runtime()),
-                        false => return Err(ZFError::PortNotFound((l.to.id, l.to.input))),
+                        true => (
+                            idx,
+                            op.get_runtime(),
+                            op.get_input_type(l.to.input.clone())?,
+                        ),
+                        false => return Err(ZFError::PortNotFound((l.to.id, l.to.input.clone()))),
                     },
                     None => return Err(ZFError::OperatorNotFound(l.to.id)),
                 };
 
+            if to_type != from_type {
+                return Err(ZFError::PortTypeNotMatching((
+                    to_type.to_string(),
+                    from_type.to_string(),
+                )));
+            }
+
             if from_runtime == to_runtime {
                 log::debug!("[Graph instantiation] [same runtime] Pushing link: {:?}", l);
                 links.push((
-                    graph.add_edge(*from_index, *to_index, l.from.output.clone()),
+                    graph.add_edge(
+                        *from_index,
+                        *to_index,
+                        (l.from.output.clone(), l.to.input.clone()),
+                    ),
                     l.clone(),
                 ));
             } else {
@@ -150,7 +171,7 @@ impl DataFlowGraph {
     }
 
     pub fn to_dot_notation(&self) -> String {
-        format!("{}", Dot::with_config(&self.graph, &[Config::EdgeNoLabel]))
+        format!("{:?}", Dot::with_config(&self.graph, &[Config::EdgeNoLabel]))
     }
 
     pub fn add_static_operator(
@@ -231,71 +252,71 @@ impl DataFlowGraph {
         Ok(())
     }
 
-    pub fn add_link(
-        &mut self,
-        from: ZFFromEndpoint,
-        to: ZFToEndpoint,
-        size: Option<usize>,
-        queueing_policy: Option<String>,
-        priority: Option<usize>,
-    ) -> ZFResult<()> {
-        let connection = ZFLinkDescriptor {
-            from,
-            to,
-            size,
-            queueing_policy,
-            priority,
-        };
+    // pub fn add_link(
+    //     &mut self,
+    //     from: ZFFromEndpoint,
+    //     to: ZFToEndpoint,
+    //     size: Option<usize>,
+    //     queueing_policy: Option<String>,
+    //     priority: Option<usize>,
+    // ) -> ZFResult<()> {
+    //     let connection = ZFLinkDescriptor {
+    //         from,
+    //         to,
+    //         size,
+    //         queueing_policy,
+    //         priority,
+    //     };
 
-        if connection.from.output == connection.to.input {
-            let from_index = match self
-                .operators
-                .iter()
-                .find(|&(_, o)| o.get_id() == connection.from.id.clone())
-            {
-                Some((idx, op)) => match op.has_output(connection.from.output.clone()) {
-                    true => idx,
-                    false => {
-                        return Err(ZFError::PortNotFound((
-                            connection.from.id.clone(),
-                            connection.from.output.clone(),
-                        )))
-                    }
-                },
-                None => return Err(ZFError::OperatorNotFound(connection.from.id.clone())),
-            };
+    //     if connection.from.output == connection.to.input {
+    //         let from_index = match self
+    //             .operators
+    //             .iter()
+    //             .find(|&(_, o)| o.get_id() == connection.from.id.clone())
+    //         {
+    //             Some((idx, op)) => match op.has_output(connection.from.output.clone()) {
+    //                 true => idx,
+    //                 false => {
+    //                     return Err(ZFError::PortNotFound((
+    //                         connection.from.id.clone(),
+    //                         connection.from.output.clone(),
+    //                     )))
+    //                 }
+    //             },
+    //             None => return Err(ZFError::OperatorNotFound(connection.from.id.clone())),
+    //         };
 
-            let to_index = match self
-                .operators
-                .iter()
-                .find(|&(_, o)| o.get_id() == connection.to.id.clone())
-            {
-                Some((idx, op)) => match op.has_input(connection.to.input.clone()) {
-                    true => idx,
-                    false => {
-                        return Err(ZFError::PortNotFound((
-                            connection.to.id.clone(),
-                            connection.to.input.clone(),
-                        )))
-                    }
-                },
-                None => return Err(ZFError::OperatorNotFound(connection.to.id.clone())),
-            };
+    //         let to_index = match self
+    //             .operators
+    //             .iter()
+    //             .find(|&(_, o)| o.get_id() == connection.to.id.clone())
+    //         {
+    //             Some((idx, op)) => match op.has_input(connection.to.input.clone()) {
+    //                 true => idx,
+    //                 false => {
+    //                     return Err(ZFError::PortNotFound((
+    //                         connection.to.id.clone(),
+    //                         connection.to.input.clone(),
+    //                     )))
+    //                 }
+    //             },
+    //             None => return Err(ZFError::OperatorNotFound(connection.to.id.clone())),
+    //         };
 
-            self.links.push((
-                self.graph
-                    .add_edge(*from_index, *to_index, connection.from.output.clone()),
-                connection,
-            ));
-        } else {
-            return Err(ZFError::PortIdNotMatching((
-                connection.from.output.clone(),
-                connection.to.input,
-            )));
-        }
+    //         self.links.push((
+    //             self.graph
+    //                 .add_edge(*from_index, *to_index, connection.from.output.clone()),
+    //             connection,
+    //         ));
+    //     } else {
+    //         return Err(ZFError::PortIdNotMatching((
+    //             connection.from.output.clone(),
+    //             connection.to.input,
+    //         )));
+    //     }
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     pub fn load(&mut self, runtime: &str) -> ZFResult<()> {
         let session = Arc::new(zenoh::net::open(zenoh::net::config::peer()).wait()?);
@@ -402,7 +423,13 @@ impl DataFlowGraph {
                         .iter()
                         .find(|&(edge_index, _)| *edge_index == down_edge_index)
                         .ok_or(ZFError::OperatorNotFound(up_op.get_id().clone()))?;
-                    let link_id = down_link.from.output.clone();
+
+                        let (link_id_from, link_id_to) = match self.graph.edge_weight(down_edge_index) {
+                            Some(w) => w,
+                            None => return Err(ZFError::GenericError),
+                        };
+
+                        //let link_id  = down_link.from.output.clone();
 
                     let down_op = match self
                         .operators
@@ -420,12 +447,13 @@ impl DataFlowGraph {
                     let mut down_runner = down_runner.lock().await;
 
                     log::debug!(
-                        "\t Creating link between {:?} -> {:?}: {:?}",
+                        "\t Creating link between {:?} -> {:?}: {:?} -> {:?}",
                         idx,
                         down_node_index,
-                        link_id
+                        link_id_from,
+                        link_id_to,
                     );
-                    let (tx, rx) = link::<ZFMessage>(None, link_id);
+                    let (tx, rx) = link::<ZFMessage>(None, String::from(link_id_from), String::from(link_id_to));
 
                     up_runner.add_output(tx);
                     down_runner.add_input(rx);

--- a/zenoh-flow/src/runtime/graph/node.rs
+++ b/zenoh-flow/src/runtime/graph/node.rs
@@ -14,7 +14,7 @@
 
 use crate::model::connector::{ZFConnectorKind, ZFConnectorRecord};
 use crate::model::operator::{ZFOperatorRecord, ZFSinkRecord, ZFSourceRecord};
-use crate::{ZFLinkId, ZFOperatorId, ZFRuntimeID};
+use crate::{ZFError, ZFLinkId, ZFOperatorId, ZFResult, ZFRuntimeID};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -45,32 +45,86 @@ impl std::fmt::Display for DataFlowNode {
 }
 
 impl DataFlowNode {
-    pub fn has_input(&self, id: ZFLinkId) -> bool {
+    pub fn has_input(&self, id: String) -> bool {
         match self {
-            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid == id) {
+            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid.name == id) {
                 Some(_lid) => true,
                 None => false,
             },
             DataFlowNode::Source(_) => false,
-            DataFlowNode::Sink(sink) => sink.input == id,
+            DataFlowNode::Sink(sink) => sink.input.name == id,
             DataFlowNode::Connector(zc) => match zc.kind {
                 ZFConnectorKind::Receiver => false,
-                ZFConnectorKind::Sender => zc.link_id == id,
+                ZFConnectorKind::Sender => zc.link_id.name == id,
             },
         }
     }
 
-    pub fn has_output(&self, id: ZFLinkId) -> bool {
+    pub fn get_input_type(&self, id: String) -> ZFResult<&str> {
         match self {
-            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid == id) {
+            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid.name == id) {
+                Some(lid) => Ok(&lid.type_name),
+                None => Err(ZFError::PortNotFound((self.get_id(), id))),
+            },
+            DataFlowNode::Source(_) => Err(ZFError::PortNotFound((self.get_id(), id))),
+            DataFlowNode::Sink(sink) => {
+                if sink.input.name == id {
+                    return Ok(&sink.input.type_name);
+                } else {
+                    return Err(ZFError::PortNotFound((self.get_id(), id)));
+                }
+            }
+            DataFlowNode::Connector(zc) => match zc.kind {
+                ZFConnectorKind::Receiver => Err(ZFError::PortNotFound((self.get_id(), id))),
+                ZFConnectorKind::Sender => {
+                    if zc.link_id.name == id {
+                        return Ok(&zc.link_id.type_name);
+                    } else {
+                        return Err(ZFError::PortNotFound((self.get_id(), id)));
+                    }
+                }
+            },
+        }
+    }
+
+    pub fn has_output(&self, id: String) -> bool {
+        match self {
+            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid.name == id) {
                 Some(_lid) => true,
                 None => false,
             },
             DataFlowNode::Sink(_) => false,
-            DataFlowNode::Source(source) => source.output == id,
+            DataFlowNode::Source(source) => source.output.name == id,
             DataFlowNode::Connector(zc) => match zc.kind {
-                ZFConnectorKind::Receiver => zc.link_id == id,
+                ZFConnectorKind::Receiver => zc.link_id.name == id,
                 ZFConnectorKind::Sender => false,
+            },
+        }
+    }
+
+    pub fn get_output_type(&self, id: String) -> ZFResult<&str> {
+        match self {
+            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid.name == id) {
+                Some(lid) => Ok(&lid.type_name),
+                None => Err(ZFError::PortNotFound((self.get_id(), id))),
+            },
+            DataFlowNode::Sink(_) => Err(ZFError::PortNotFound((self.get_id(), id))),
+            DataFlowNode::Source(source) => {
+                if source.output.name == id {
+                    return Ok(&source.output.type_name);
+                } else {
+                    return Err(ZFError::PortNotFound((self.get_id(), id)));
+                }
+            }
+            DataFlowNode::Connector(zc) => match zc.kind {
+                ZFConnectorKind::Receiver => {
+                    if zc.link_id.name == id {
+                        return Ok(&zc.link_id.type_name);
+                    } else {
+                        return Err(ZFError::PortNotFound((self.get_id(), id)));
+                    }
+                }
+                ZFConnectorKind::Sender => Err(ZFError::PortNotFound((self.get_id(), id))),
             },
         }
     }

--- a/zenoh-flow/src/runtime/graph/node.rs
+++ b/zenoh-flow/src/runtime/graph/node.rs
@@ -14,7 +14,7 @@
 
 use crate::model::connector::{ZFConnectorKind, ZFConnectorRecord};
 use crate::model::operator::{ZFOperatorRecord, ZFSinkRecord, ZFSourceRecord};
-use crate::{ZFError, ZFLinkId, ZFOperatorId, ZFResult, ZFRuntimeID};
+use crate::{ZFError, ZFOperatorId, ZFResult, ZFRuntimeID};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -47,29 +47,29 @@ impl std::fmt::Display for DataFlowNode {
 impl DataFlowNode {
     pub fn has_input(&self, id: String) -> bool {
         match self {
-            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid.name == id) {
+            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid.port_id == id) {
                 Some(_lid) => true,
                 None => false,
             },
             DataFlowNode::Source(_) => false,
-            DataFlowNode::Sink(sink) => sink.input.name == id,
+            DataFlowNode::Sink(sink) => sink.input.port_id == id,
             DataFlowNode::Connector(zc) => match zc.kind {
                 ZFConnectorKind::Receiver => false,
-                ZFConnectorKind::Sender => zc.link_id.name == id,
+                ZFConnectorKind::Sender => zc.link_id.port_id == id,
             },
         }
     }
 
     pub fn get_input_type(&self, id: String) -> ZFResult<&str> {
         match self {
-            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid.name == id) {
-                Some(lid) => Ok(&lid.type_name),
+            DataFlowNode::Operator(op) => match op.inputs.iter().find(|&lid| *lid.port_id == id) {
+                Some(lid) => Ok(&lid.port_type),
                 None => Err(ZFError::PortNotFound((self.get_id(), id))),
             },
             DataFlowNode::Source(_) => Err(ZFError::PortNotFound((self.get_id(), id))),
             DataFlowNode::Sink(sink) => {
-                if sink.input.name == id {
-                    return Ok(&sink.input.type_name);
+                if sink.input.port_id == id {
+                    return Ok(&sink.input.port_type);
                 } else {
                     return Err(ZFError::PortNotFound((self.get_id(), id)));
                 }
@@ -77,8 +77,8 @@ impl DataFlowNode {
             DataFlowNode::Connector(zc) => match zc.kind {
                 ZFConnectorKind::Receiver => Err(ZFError::PortNotFound((self.get_id(), id))),
                 ZFConnectorKind::Sender => {
-                    if zc.link_id.name == id {
-                        return Ok(&zc.link_id.type_name);
+                    if zc.link_id.port_id == id {
+                        return Ok(&zc.link_id.port_type);
                     } else {
                         return Err(ZFError::PortNotFound((self.get_id(), id)));
                     }
@@ -89,14 +89,14 @@ impl DataFlowNode {
 
     pub fn has_output(&self, id: String) -> bool {
         match self {
-            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid.name == id) {
+            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid.port_id == id) {
                 Some(_lid) => true,
                 None => false,
             },
             DataFlowNode::Sink(_) => false,
-            DataFlowNode::Source(source) => source.output.name == id,
+            DataFlowNode::Source(source) => source.output.port_id == id,
             DataFlowNode::Connector(zc) => match zc.kind {
-                ZFConnectorKind::Receiver => zc.link_id.name == id,
+                ZFConnectorKind::Receiver => zc.link_id.port_id == id,
                 ZFConnectorKind::Sender => false,
             },
         }
@@ -104,22 +104,22 @@ impl DataFlowNode {
 
     pub fn get_output_type(&self, id: String) -> ZFResult<&str> {
         match self {
-            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid.name == id) {
-                Some(lid) => Ok(&lid.type_name),
+            DataFlowNode::Operator(op) => match op.outputs.iter().find(|&lid| *lid.port_id == id) {
+                Some(lid) => Ok(&lid.port_type),
                 None => Err(ZFError::PortNotFound((self.get_id(), id))),
             },
             DataFlowNode::Sink(_) => Err(ZFError::PortNotFound((self.get_id(), id))),
             DataFlowNode::Source(source) => {
-                if source.output.name == id {
-                    return Ok(&source.output.type_name);
+                if source.output.port_id == id {
+                    return Ok(&source.output.port_type);
                 } else {
                     return Err(ZFError::PortNotFound((self.get_id(), id)));
                 }
             }
             DataFlowNode::Connector(zc) => match zc.kind {
                 ZFConnectorKind::Receiver => {
-                    if zc.link_id.name == id {
-                        return Ok(&zc.link_id.type_name);
+                    if zc.link_id.port_id == id {
+                        return Ok(&zc.link_id.port_type);
                     } else {
                         return Err(ZFError::PortNotFound((self.get_id(), id)));
                     }

--- a/zenoh-flow/src/runtime/message.rs
+++ b/zenoh-flow/src/runtime/message.rs
@@ -14,12 +14,13 @@
 
 extern crate serde;
 
-use crate::{DataTrait, ZFTimestamp};
+use crate::DataTrait;
 use async_std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use uhlc::Timestamp;
 
-//TODO: improve
+// TODO: improve
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ZFDataMessage {
     Serialized(Arc<Vec<u8>>),
@@ -66,36 +67,42 @@ pub enum Message {
     Ctrl(ZFCtrlMessage),
 }
 
-//TODO: improve
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ZFMessage {
-    pub ts: ZFTimestamp,
-    pub msg: Message,
-}
-
-impl ZFMessage {
+impl Message {
     pub fn from_raw(data: Arc<Vec<u8>>) -> Self {
-        Self {
-            ts: 0, //placeholder
-            msg: Message::Data(ZFDataMessage::new_serialized(data)),
-        }
+        Message::Data(ZFDataMessage::new_serialized(data))
     }
 
     pub fn from_data(data: Arc<dyn DataTrait>) -> Self {
+        Message::Data(ZFDataMessage::new_deserialized(data))
+    }
+}
+
+// TODO: improve
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZFMessage {
+    pub timestamp: Timestamp,
+    pub message: Message,
+}
+
+impl ZFMessage {
+    pub fn from_raw(timestamp: Timestamp, data: Arc<Vec<u8>>) -> Self {
         Self {
-            ts: 0, //placeholder
-            msg: Message::Data(ZFDataMessage::new_deserialized(data)),
+            timestamp,
+            message: Message::from_raw(data),
         }
     }
 
-    pub fn from_message(msg: ZFDataMessage) -> Self {
+    pub fn from_data(timestamp: Timestamp, data: Arc<dyn DataTrait>) -> Self {
         Self {
-            ts: 0, //placeholder
-            msg: Message::Data(msg),
+            timestamp,
+            message: Message::from_data(data),
         }
     }
 
-    pub fn timestamp(&self) -> &ZFTimestamp {
-        &self.ts
+    pub fn from_message(timestamp: Timestamp, msg: ZFDataMessage) -> Self {
+        Self {
+            timestamp,
+            message: Message::Data(msg),
+        }
     }
 }

--- a/zenoh-flow/src/runtime/runner.rs
+++ b/zenoh-flow/src/runtime/runner.rs
@@ -16,7 +16,7 @@ use crate::async_std::sync::Arc;
 use crate::runtime::connectors::{ZFZenohReceiver, ZFZenohSender};
 use crate::runtime::graph::link::{ZFLinkReceiver, ZFLinkSender};
 use crate::runtime::message::{Message, ZFMessage};
-use crate::types::{Token, ZFContext, ZFData, ZFInput, ZFLinkId, ZFResult};
+use crate::types::{Token, ZFContext, ZFData, ZFInput, ZFLinkId, ZFResult, ZFError};
 use crate::{OperatorTrait, SinkTrait, SourceTrait};
 use futures::future;
 use libloading::Library;

--- a/zenoh-flow/src/runtime/runner.rs
+++ b/zenoh-flow/src/runtime/runner.rs
@@ -16,7 +16,7 @@ use crate::async_std::sync::Arc;
 use crate::runtime::connectors::{ZFZenohReceiver, ZFZenohSender};
 use crate::runtime::graph::link::{ZFLinkReceiver, ZFLinkSender};
 use crate::runtime::message::{Message, ZFMessage};
-use crate::types::{Token, ZFContext, ZFData, ZFInput, ZFLinkId, ZFResult, ZFError};
+use crate::types::{Token, ZFContext, ZFData, ZFInput, ZFResult};
 use crate::{OperatorTrait, SinkTrait, SourceTrait};
 use futures::future;
 use libloading::Library;
@@ -116,7 +116,7 @@ impl ZFOperatorRunner {
         let ctx = ZFContext::new(self.operator.get_state(), 0);
 
         loop {
-            // we should start from an HashMap with all ZFLinkId and not ready tokens
+            // we should start from an HashMap with all PortId and not ready tokens
             let mut msgs: HashMap<String, Token> = HashMap::new();
 
             for i in &self.inputs {
@@ -321,7 +321,7 @@ impl ZFSinkRunner {
         let ctx = ZFContext::new(self.operator.get_state(), 0);
 
         loop {
-            // we should start from an HashMap with all ZFLinkId and not ready tokens
+            // we should start from an HashMap with all PortId and not ready tokens
             let mut msgs: HashMap<String, Token> = HashMap::new();
 
             for i in self.inputs.iter() {

--- a/zenoh-flow/src/runtime/runner.rs
+++ b/zenoh-flow/src/runtime/runner.rs
@@ -43,6 +43,7 @@ impl Runner {
     }
 
     pub fn add_input(&mut self, input: ZFLinkReceiver<ZFMessage>) {
+        log::trace!("add_input({:?})", input);
         match self {
             Runner::Operator(runner) => runner.add_input(input),
             Runner::Source(_) => panic!("Sources does not have inputs!"), // TODO this should return a ZFResult<()>
@@ -53,6 +54,7 @@ impl Runner {
     }
 
     pub fn add_output(&mut self, output: ZFLinkSender<ZFMessage>) {
+        log::trace!("add_output({:?})", output);
         match self {
             Runner::Operator(runner) => runner.add_output(output),
             Runner::Source(runner) => runner.add_output(output),
@@ -76,7 +78,7 @@ pub struct ZFOperatorRunner {
     pub operator: Box<dyn OperatorTrait + Send>,
     pub lib: Option<Library>,
     pub inputs: Vec<ZFLinkReceiver<ZFMessage>>,
-    pub outputs: HashMap<ZFLinkId, Vec<ZFLinkSender<ZFMessage>>>,
+    pub outputs: HashMap<String, Vec<ZFLinkSender<ZFMessage>>>,
 }
 
 impl ZFOperatorRunner {
@@ -108,7 +110,7 @@ impl ZFOperatorRunner {
 
         loop {
             // we should start from an HashMap with all ZFLinkId and not ready tokens
-            let mut msgs: HashMap<ZFLinkId, Token> = HashMap::new();
+            let mut msgs: HashMap<String, Token> = HashMap::new();
 
             for i in &self.inputs {
                 msgs.insert(i.id(), Token::new_not_ready(0));
@@ -289,7 +291,7 @@ impl ZFSinkRunner {
 
         loop {
             // we should start from an HashMap with all ZFLinkId and not ready tokens
-            let mut msgs: HashMap<ZFLinkId, Token> = HashMap::new();
+            let mut msgs: HashMap<String, Token> = HashMap::new();
 
             for i in self.inputs.iter() {
                 msgs.insert(i.id(), Token::new_not_ready(0));

--- a/zenoh-flow/src/runtime/runner.rs
+++ b/zenoh-flow/src/runtime/runner.rs
@@ -44,6 +44,7 @@ impl Runner {
     }
 
     pub fn add_input(&mut self, input: ZFLinkReceiver<ZFMessage>) {
+        log::trace!("add_input({:?})", input);
         match self {
             Runner::Operator(runner) => runner.add_input(input),
             Runner::Source(_) => panic!("Sources does not have inputs!"), // TODO this should return a ZFResult<()>
@@ -54,6 +55,7 @@ impl Runner {
     }
 
     pub fn add_output(&mut self, output: ZFLinkSender<ZFMessage>) {
+        log::trace!("add_output({:?})", output);
         match self {
             Runner::Operator(runner) => runner.add_output(output),
             Runner::Source(runner) => runner.add_output(output),
@@ -78,7 +80,7 @@ pub struct ZFOperatorRunner {
     pub operator: Box<dyn OperatorTrait + Send>,
     pub lib: Option<Library>,
     pub inputs: Vec<ZFLinkReceiver<ZFMessage>>,
-    pub outputs: HashMap<ZFLinkId, Vec<ZFLinkSender<ZFMessage>>>,
+    pub outputs: HashMap<String, Vec<ZFLinkSender<ZFMessage>>>,
 }
 
 impl ZFOperatorRunner {
@@ -115,7 +117,7 @@ impl ZFOperatorRunner {
 
         loop {
             // we should start from an HashMap with all ZFLinkId and not ready tokens
-            let mut msgs: HashMap<ZFLinkId, Token> = HashMap::new();
+            let mut msgs: HashMap<String, Token> = HashMap::new();
 
             for i in &self.inputs {
                 msgs.insert(i.id(), Token::NotReady);
@@ -320,7 +322,7 @@ impl ZFSinkRunner {
 
         loop {
             // we should start from an HashMap with all ZFLinkId and not ready tokens
-            let mut msgs: HashMap<ZFLinkId, Token> = HashMap::new();
+            let mut msgs: HashMap<String, Token> = HashMap::new();
 
             for i in self.inputs.iter() {
                 msgs.insert(i.id(), Token::NotReady);

--- a/zenoh-flow/src/runtime/runner.rs
+++ b/zenoh-flow/src/runtime/runner.rs
@@ -217,7 +217,7 @@ pub struct ZFSourceRunner {
     pub hlc: Arc<HLC>,
     pub operator: Box<dyn SourceTrait + Send>,
     pub lib: Option<Library>,
-    pub outputs: HashMap<ZFLinkId, Vec<ZFLinkSender<ZFMessage>>>,
+    pub outputs: HashMap<String, Vec<ZFLinkSender<ZFMessage>>>,
 }
 
 impl ZFSourceRunner {

--- a/zenoh-flow/src/runtime/runner.rs
+++ b/zenoh-flow/src/runtime/runner.rs
@@ -16,7 +16,7 @@ use crate::async_std::sync::Arc;
 use crate::runtime::connectors::{ZFZenohReceiver, ZFZenohSender};
 use crate::runtime::graph::link::{ZFLinkReceiver, ZFLinkSender};
 use crate::runtime::message::{Message, ZFMessage};
-use crate::types::{Token, ZFContext, ZFData, ZFInput, ZFLinkId, ZFResult};
+use crate::types::{Token, ZFContext, ZFData, ZFInput, ZFLinkId, ZFResult, ZFError};
 use crate::{OperatorTrait, SinkTrait, SourceTrait};
 use futures::future;
 use libloading::Library;
@@ -229,7 +229,7 @@ impl ZFSourceRunner {
             for (id, zf_msg) in out_msgs {
                 log::debug!("Sending on {:?} data: {:?}", id, zf_msg);
                 //getting link
-                let tx = self.outputs.iter().find(|&x| x.id() == id).unwrap();
+                let tx = self.outputs.iter().find(|&x| x.id() == id).ok_or(ZFError::MissingOutput(id))?;
                 //println!("Tx: {:?} Receivers: {:?}", tx.inner.tx, tx.inner.tx.receiver_count());
                 match zf_msg.msg {
                     Message::Data(_) => {

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -51,13 +51,13 @@ pub enum ZFError {
     VersionMismatch,
     Disconnected,
     Uncompleted(String),
-    // PortIdNotMatching((ZFLinkId, ZFLinkId)),
     PortTypeNotMatching((String, String)),
     OperatorNotFound(ZFOperatorId),
     PortNotFound((ZFOperatorId, String)),
     RecvError(flume::RecvError),
     SendError(String),
     MissingInput(String),
+    MissingOutput(String),
     InvalidData(String),
     IOError(String),
     ZenohError(String),
@@ -452,10 +452,7 @@ pub fn default_output_rule(
     Ok(results)
 }
 
-pub fn default_input_rule(
-    _ctx: ZFContext,
-    inputs: &mut HashMap<String, Token>,
-) -> InputRuleResult {
+pub fn default_input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
     for token in inputs.values() {
         match token {
             Token::Ready(_) => continue,

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -159,7 +159,7 @@ pub type InputRuleResult = ZFResult<bool>;
 pub type FnInputRule =
     dyn Fn(ZFContext, &mut HashMap<String, Token>) -> InputRuleResult + Send + Sync + 'static;
 
-pub type OutputRuleResult = ZFResult<HashMap<ZFLinkId, Message>>;
+pub type OutputRuleResult = ZFResult<HashMap<String, Message>>;
 
 pub type FnOutputRule = dyn Fn(ZFContext, HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleResult
     + Send

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -32,10 +32,11 @@ pub type ZFTimestamp = usize; //TODO: improve it, usize is just a placeholder
 pub type ZFRuntimeID = String;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ZFLinkId {
-    pub name: String,
+pub struct ZFPortDescriptor {
+    #[serde(alias = "id")]
+    pub port_id: String,
     #[serde(alias = "type")]
-    pub type_name: String,
+    pub port_type: String,
 }
 
 #[derive(Debug, PartialEq)]

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -50,13 +50,13 @@ pub enum ZFError {
     VersionMismatch,
     Disconnected,
     Uncompleted(String),
-    // PortIdNotMatching((ZFLinkId, ZFLinkId)),
     PortTypeNotMatching((String, String)),
     OperatorNotFound(ZFOperatorId),
     PortNotFound((ZFOperatorId, String)),
     RecvError(flume::RecvError),
     SendError(String),
     MissingInput(String),
+    MissingOutput(String),
     InvalidData(String),
     IOError(String),
     ZenohError(String),
@@ -459,10 +459,7 @@ pub fn default_output_rule(
     Ok(results)
 }
 
-pub fn default_input_rule(
-    _ctx: ZFContext,
-    inputs: &mut HashMap<String, Token>,
-) -> InputRuleResult {
+pub fn default_input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
     for token in inputs.values() {
         match token {
             Token::Ready(_) => continue,

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -27,8 +27,15 @@ pub type ZFOperatorId = String;
 pub type ZFZenohResource = String;
 pub type ZFOperatorName = String;
 pub type ZFTimestamp = usize; //TODO: improve it, usize is just a placeholder
-pub type ZFLinkId = String; // TODO: improve it, String is just a placeholder
+
 pub type ZFRuntimeID = String;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ZFLinkId {
+    pub name: String,
+    #[serde(alias = "type")]
+    pub type_name: String,
+}
 
 #[derive(Debug, PartialEq)]
 pub enum ZFError {
@@ -43,13 +50,14 @@ pub enum ZFError {
     VersionMismatch,
     Disconnected,
     Uncompleted(String),
-    PortIdNotMatching((ZFLinkId, ZFLinkId)),
+    // PortIdNotMatching((ZFLinkId, ZFLinkId)),
+    PortTypeNotMatching((String, String)),
     OperatorNotFound(ZFOperatorId),
-    PortNotFound((ZFOperatorId, ZFLinkId)),
+    PortNotFound((ZFOperatorId, String)),
     RecvError(flume::RecvError),
     SendError(String),
-    MissingInput(ZFLinkId),
-    InvalidData(ZFLinkId),
+    MissingInput(String),
+    InvalidData(String),
     IOError(String),
     ZenohError(String),
     LoadingError(String),
@@ -151,16 +159,16 @@ pub type InputRuleResult = ZFResult<bool>;
 
 // CAUTION, USER CAN DO NASTY THINGS, eg. remove a link we have passed to him.
 pub type FnInputRule =
-    dyn Fn(ZFContext, &mut HashMap<ZFLinkId, Token>) -> InputRuleResult + Send + Sync + 'static;
+    dyn Fn(ZFContext, &mut HashMap<String, Token>) -> InputRuleResult + Send + Sync + 'static;
 
-pub type OutputRuleResult = ZFResult<HashMap<ZFLinkId, Arc<ZFMessage>>>;
+pub type OutputRuleResult = ZFResult<HashMap<String, Arc<ZFMessage>>>;
 
-pub type FnOutputRule = dyn Fn(ZFContext, HashMap<ZFLinkId, Arc<dyn DataTrait>>) -> OutputRuleResult
+pub type FnOutputRule = dyn Fn(ZFContext, HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleResult
     + Send
     + Sync
     + 'static;
 
-pub type RunResult = ZFResult<HashMap<ZFLinkId, Arc<dyn DataTrait>>>;
+pub type RunResult = ZFResult<HashMap<String, Arc<dyn DataTrait>>>;
 
 pub type FnRun = dyn Fn(ZFContext, ZFInput) -> RunResult + Send + Sync + 'static;
 
@@ -396,29 +404,29 @@ impl From<TokenData> for ZFData {
 }
 
 #[derive(Debug, Clone)]
-pub struct ZFInput(HashMap<ZFLinkId, ZFData>);
+pub struct ZFInput(HashMap<String, ZFData>);
 
 impl ZFInput {
     pub fn new() -> Self {
         Self(HashMap::new())
     }
 
-    pub fn insert(&mut self, id: ZFLinkId, data: ZFData) -> Option<ZFData> {
+    pub fn insert(&mut self, id: String, data: ZFData) -> Option<ZFData> {
         self.0.insert(id, data)
     }
 
-    pub fn get(&self, id: &ZFLinkId) -> Option<&ZFData> {
+    pub fn get(&self, id: &String) -> Option<&ZFData> {
         self.0.get(id)
     }
 
-    pub fn get_mut(&mut self, id: &ZFLinkId) -> Option<&mut ZFData> {
+    pub fn get_mut(&mut self, id: &String) -> Option<&mut ZFData> {
         self.0.get_mut(id)
     }
 }
 
 impl<'a> IntoIterator for &'a ZFInput {
-    type Item = (&'a ZFLinkId, &'a ZFData);
-    type IntoIter = std::collections::hash_map::Iter<'a, ZFLinkId, ZFData>;
+    type Item = (&'a String, &'a ZFData);
+    type IntoIter = std::collections::hash_map::Iter<'a, String, ZFData>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -441,7 +449,7 @@ impl StateTrait for EmptyState {
 
 pub fn default_output_rule(
     _ctx: ZFContext,
-    outputs: HashMap<ZFLinkId, Arc<dyn DataTrait>>,
+    outputs: HashMap<String, Arc<dyn DataTrait>>,
 ) -> OutputRuleResult {
     let mut results = HashMap::new();
     for (k, v) in outputs {
@@ -453,7 +461,7 @@ pub fn default_output_rule(
 
 pub fn default_input_rule(
     _ctx: ZFContext,
-    inputs: &mut HashMap<ZFLinkId, Token>,
+    inputs: &mut HashMap<String, Token>,
 ) -> InputRuleResult {
     for token in inputs.values() {
         match token {

--- a/zenoh-flow/tests/link.rs
+++ b/zenoh-flow/tests/link.rs
@@ -18,33 +18,34 @@ use zenoh_flow::{ZFError, ZFResult};
 
 async fn same_task_simple() {
     let size = 2;
-    let id = String::from("0");
-    let (sender, mut receiver) = link::<u8>(Some(size), id);
+    let send_id = String::from("0");
+    let recv_id = String::from("10");
+    let (sender, mut receiver) = link::<u8>(Some(size), send_id, recv_id);
 
     let mut d: u8 = 0;
     // Add the first element
     let res = sender.send(Arc::new(d)).await;
     assert_eq!(res, Ok(()));
     let res = receiver.recv().await;
-    assert_eq!(res, Ok((String::from("0"), Arc::new(0u8))));
+    assert_eq!(res, Ok((String::from("10"), Arc::new(0u8))));
 
     // Add the second element
     d = d + 1;
     let res = sender.send(Arc::new(d)).await;
     assert_eq!(res, Ok(()));
     let res = receiver.recv().await;
-    assert_eq!(res, Ok((String::from("0"), Arc::new(1u8))));
+    assert_eq!(res, Ok((String::from("10"), Arc::new(1u8))));
 }
 
 async fn recv_task_simple(mut receiver: ZFLinkReceiver<u8>) {
     let res = receiver.recv().await;
-    assert_eq!(res, Ok((String::from("0"), Arc::new(0u8))));
+    assert_eq!(res, Ok((String::from("10"), Arc::new(0u8))));
 
     let res = receiver.recv().await;
-    assert_eq!(res, Ok((String::from("0"), Arc::new(1u8))));
+    assert_eq!(res, Ok((String::from("10"), Arc::new(1u8))));
 
     let res = receiver.recv().await;
-    assert_eq!(res, Ok((String::from("0"), Arc::new(2u8))));
+    assert_eq!(res, Ok((String::from("10"), Arc::new(2u8))));
 }
 
 async fn send_task_simple(sender: ZFLinkSender<u8>) {
@@ -66,7 +67,7 @@ async fn send_task_simple(sender: ZFLinkSender<u8>) {
 async fn recv_task_more(mut receiver: ZFLinkReceiver<u8>) {
     for n in 0u8..255u8 {
         let res = receiver.recv().await;
-        assert_eq!(res, Ok((String::from("0"), Arc::new(n))));
+        assert_eq!(res, Ok((String::from("10"), Arc::new(n))));
     }
 }
 
@@ -85,8 +86,9 @@ fn ordered_fifo_simple_async() {
 #[test]
 fn ordered_fifo_simple_two_task_async() {
     let size = 2;
-    let id = String::from("0");
-    let (sender, receiver) = link::<u8>(Some(size), id);
+    let send_id = String::from("0");
+    let recv_id = String::from("10");
+    let (sender, receiver) = link::<u8>(Some(size), send_id, recv_id);
 
     let h1 = async_std::task::spawn(async move { send_task_simple(sender).await });
 
@@ -101,8 +103,9 @@ fn ordered_fifo_simple_two_task_async() {
 #[test]
 fn ordered_fifo_more_two_task_async() {
     let size = 20;
-    let id = String::from("0");
-    let (sender, receiver) = link::<u8>(Some(size), id);
+    let send_id = String::from("0");
+    let recv_id = String::from("10");
+    let (sender, receiver) = link::<u8>(Some(size), send_id, recv_id);
 
     let h1 = async_std::task::spawn(async move { send_task_more(sender).await });
 


### PR DESCRIPTION
The current description for the port of an operator is based on a simple `String` and the runtime checks if the port has the same name when connecting two nodes.

While this works in most cases it requires having the **same** name for the port to be connected, this can be an issue in cases like the figure below.

![Same type different name](https://user-images.githubusercontent.com/4215504/126444901-10f10772-af3c-4ab9-a07c-884ac08abea6.png)

Therefore with this PR, we changed the description of the port to have **name** and **type**.
The `ZFLinkId` type becomes:

```rust
#[derive(Debug, Serialize, Deserialize, Clone)]
pub struct ZFLinkId {
    pub name: String,
    #[serde(alias = "type")]
    pub type_name: String,
}
```


The runtime will check if the **type** is matching when connecting nodes.

This is an example of the updated description for an operator:

```yaml
  - id: BuzzOperator
    uri: file://./target/debug/examples/libexample_buzz.dylib
    inputs:
      - name: Int
        type: u64
      - name: Str
        type: string
    outputs:
      - name: Str
        type: string
```

The above graph can be specified by this descriptor:
```yaml
flow: MergingPipeline
operators:
  - id : Concatenation 
    uri: file://./target/release/examples/libframe_concat.so
    inputs:
      - name: Frame1
        type: image
      - name: Frame2
        type: image
    outputs:
      - name: Frame
        type: image  
sources: 
  - id : Camera0
    uri: file://./target/release/examples/libvideo_file_source.so
    output:
        name: Frame
        type: image
    configuration:
      file: /home/luca/Workspace/experiments/I2.mp4
      fps: 15
  - id : Camera1
    uri: file://./target/release/examples/libvideo_file_source.so
    output:
        name: Frame
        type: image
    configuration:
      file: /home/luca/Workspace/experiments/I1.mp4
      fps: 15
sinks: 
  - id : Window
    uri: file://./target/release/examples/libvideo_sink.so
    input:
      name: Frame
      type: image
links:
- from:
    id : Camera0
    output : Frame # Output
  to:
    id : Concatenation
    input : Frame1 # Input
- from:
    id : Camera1
    output : Frame
  to:
    id : Concatenation
    input : Frame2
- from:
      id: Concatenation
      output: Frame
  to:
      id: Window
      input: Frame
```
  
  
  Any comment is more than welcome. 
